### PR TITLE
fix: use relative URLs for API calls, fix Docker/remote deployment

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,3 @@
-# Backend URL (optional, defaults to http://localhost:3008)
-NEXT_PUBLIC_BACKEND_URL=http://localhost:3008
+# Backend URL (optional, defaults to relative URL — same origin)
+# Only set this if the API is on a different host/port than the frontend
+# NEXT_PUBLIC_BACKEND_URL=http://localhost:3008

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beads-web",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "scripts": {
     "dev": "next dev -p 3007",
     "build": "next build",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beads-server"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beads-server"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/server/src/dolt.rs
+++ b/server/src/dolt.rs
@@ -17,12 +17,12 @@ use crate::routes::beads::{Bead, Comment};
 
 /// Dolt server connection parameters from environment variables (with defaults).
 /// Values are read once at first access and cached for the process lifetime.
-fn dolt_host() -> &'static str {
+pub fn dolt_host() -> &'static str {
     static V: OnceLock<String> = OnceLock::new();
     V.get_or_init(|| std::env::var("DOLT_HOST").unwrap_or_else(|_| "127.0.0.1".into()))
 }
 
-fn dolt_port() -> u16 {
+pub fn dolt_port() -> u16 {
     static V: OnceLock<u16> = OnceLock::new();
     *V.get_or_init(|| match std::env::var("DOLT_PORT") {
         Ok(p) => p.parse().expect("DOLT_PORT must be a valid port number"),
@@ -715,5 +715,17 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         let obj = parsed.as_object().unwrap();
         assert_eq!(obj.len(), 2);
+    }
+
+    // ── dolt_host / dolt_port default value tests ────────────────────────
+
+    #[test]
+    fn test_dolt_host_default() {
+        assert_eq!(dolt_host(), "127.0.0.1");
+    }
+
+    #[test]
+    fn test_dolt_port_default() {
+        assert_eq!(dolt_port(), 3307);
     }
 }

--- a/server/src/dolt.rs
+++ b/server/src/dolt.rs
@@ -9,15 +9,48 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 use tokio::net::TcpStream;
 use tracing::info;
 
 use crate::routes::beads::{Bead, Comment};
 
-/// Default Dolt server connection parameters (configured by bd CLI).
-const DOLT_HOST: &str = "127.0.0.1";
-const DOLT_PORT: u16 = 3307;
-const DOLT_USER: &str = "root";
+/// Dolt server connection parameters from environment variables (with defaults).
+/// Values are read once at first access and cached for the process lifetime.
+fn dolt_host() -> &'static str {
+    static V: OnceLock<String> = OnceLock::new();
+    V.get_or_init(|| std::env::var("DOLT_HOST").unwrap_or_else(|_| "127.0.0.1".into()))
+}
+
+fn dolt_port() -> u16 {
+    static V: OnceLock<u16> = OnceLock::new();
+    *V.get_or_init(|| match std::env::var("DOLT_PORT") {
+        Ok(p) => p.parse().expect("DOLT_PORT must be a valid port number"),
+        Err(_) => 3307,
+    })
+}
+
+fn dolt_user() -> &'static str {
+    static V: OnceLock<String> = OnceLock::new();
+    V.get_or_init(|| std::env::var("DOLT_USER").unwrap_or_else(|_| "root".into()))
+}
+
+fn dolt_password() -> Option<&'static str> {
+    static V: OnceLock<Option<String>> = OnceLock::new();
+    V.get_or_init(|| std::env::var("DOLT_PASSWORD").ok()).as_deref()
+}
+
+/// Builds mysql_async connection options with Dolt env var config.
+/// Port is passed explicitly (callers may override with per-project port).
+fn build_dolt_opts(port: u16, pool_opts: PoolOpts) -> Opts {
+    OptsBuilder::default()
+        .ip_or_hostname(dolt_host())
+        .tcp_port(port)
+        .user(Some(dolt_user()))
+        .pass(dolt_password())
+        .pool_opts(pool_opts)
+        .into()
+}
 
 /// Errors from Dolt operations.
 #[derive(Debug, thiserror::Error)]
@@ -44,12 +77,7 @@ impl DoltManager {
         let pool_opts = PoolOpts::default()
             .with_constraints(PoolConstraints::new(0, 4).unwrap());
 
-        let opts: Opts = OptsBuilder::default()
-            .ip_or_hostname(DOLT_HOST)
-            .tcp_port(DOLT_PORT)
-            .user(Some(DOLT_USER))
-            .pool_opts(pool_opts)
-            .into();
+        let opts = build_dolt_opts(dolt_port(), pool_opts);
 
         Self {
             pool: Pool::new(opts),
@@ -59,7 +87,7 @@ impl DoltManager {
 
     /// Checks if Dolt server is reachable via TCP.
     pub async fn check_server(&self) -> bool {
-        let reachable = TcpStream::connect((DOLT_HOST, DOLT_PORT)).await.is_ok();
+        let reachable = TcpStream::connect((dolt_host(), dolt_port())).await.is_ok();
         self.available.store(reachable, Ordering::Relaxed);
         reachable
     }
@@ -262,14 +290,7 @@ pub async fn read_beads_on_port(port: u16, db_name: &str) -> Result<Vec<Bead>, D
     let pool_opts = PoolOpts::default()
         .with_constraints(PoolConstraints::new(0, 2).unwrap());
 
-    let opts: Opts = OptsBuilder::default()
-        .ip_or_hostname(DOLT_HOST)
-        .tcp_port(port)
-        .user(Some(DOLT_USER))
-        .pool_opts(pool_opts)
-        .into();
-
-    let pool = Pool::new(opts);
+    let pool = Pool::new(build_dolt_opts(port, pool_opts));
     let mut conn = pool.get_conn().await
         .map_err(|e| DoltError::ConnectionFailed(e.to_string()))?;
 
@@ -291,14 +312,7 @@ pub async fn discover_database_on_port(port: u16) -> Result<String, DoltError> {
     let pool_opts = PoolOpts::default()
         .with_constraints(PoolConstraints::new(0, 2).unwrap());
 
-    let opts: Opts = OptsBuilder::default()
-        .ip_or_hostname(DOLT_HOST)
-        .tcp_port(port)
-        .user(Some(DOLT_USER))
-        .pool_opts(pool_opts)
-        .into();
-
-    let pool = Pool::new(opts);
+    let pool = Pool::new(build_dolt_opts(port, pool_opts));
     let mut conn = pool.get_conn().await
         .map_err(|e| DoltError::ConnectionFailed(e.to_string()))?;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -111,9 +111,9 @@ async fn main() {
     // Initialize Dolt connection manager
     let dolt_manager = Arc::new(dolt::DoltManager::new());
     if dolt_manager.check_server().await {
-        info!("Dolt server is available on port 3307");
+        info!("Dolt server is available at {}:{}", dolt::dolt_host(), dolt::dolt_port());
     } else {
-        info!("Dolt server not detected — will use bd CLI / JSONL fallback");
+        info!("Dolt server not detected at {}:{} — will use bd CLI / JSONL fallback", dolt::dolt_host(), dolt::dolt_port());
     }
 
     // Check for bd CLI availability and compatibility
@@ -204,8 +204,10 @@ async fn main() {
 
     info!("Server starting on http://localhost:{}", port);
 
-    // Open default browser
-    if let Err(e) = open::that(format!("http://localhost:{}", port)) {
+    // Open default browser unless suppressed (e.g., Docker/headless)
+    if env::var("NO_BROWSER").is_ok() {
+        info!("Browser auto-open suppressed (NO_BROWSER is set)");
+    } else if let Err(e) = open::that(format!("http://localhost:{}", port)) {
         tracing::warn!("Failed to open browser: {}", e);
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -216,7 +216,7 @@ export default function ProjectsPage() {
             <div role="alert" className="rounded-lg border border-danger/50 bg-danger/70 p-6 text-center">
               <p className="text-danger">Error loading projects: {error.message}</p>
               <p className="mt-2 text-sm text-danger">
-                Make sure the Tauri backend is running.
+                Make sure the backend server is running.
               </p>
             </div>
           ) : filteredProjects.length === 0 ? (

--- a/src/components/design-doc-viewer.tsx
+++ b/src/components/design-doc-viewer.tsx
@@ -21,7 +21,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import "highlight.js/styles/github-dark.css";
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 export interface DesignDocViewerProps {
   /** Path to design doc (e.g., ".designs/{EPIC_ID}.md") */

--- a/src/components/update-banner.tsx
+++ b/src/components/update-banner.tsx
@@ -53,7 +53,7 @@ export function UpdateBanner() {
         const checkServer = async () => {
           for (let i = 0; i < 20; i++) {
             try {
-              await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008'}/api/health`, {
+              await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL || ''}/api/health`, {
                 signal: AbortSignal.timeout(2000),
               });
               window.location.reload();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,12 +1,12 @@
 /**
  * Frontend API layer for beads-kanban-ui webapp
- * Replaces Tauri invoke() calls with HTTP fetch to backend
+ * HTTP fetch to backend — uses relative URLs (same origin) by default
  */
 
 import { BeadsResponseSchema, PRStatusSchema, WorktreeStatusSchema } from '@/lib/api-schemas';
 import type { Project, Tag, Bead, WorktreeStatus, WorktreeEntry, PRStatus, PRFilesResponse, MemoryResponse, MemoryStats, MemoryEntry, Agent, AgentModel } from '@/types';
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 /**
  * Input for creating a new project

--- a/src/lib/design-doc.ts
+++ b/src/lib/design-doc.ts
@@ -3,7 +3,7 @@
  * Shared functions for fetching and processing design documents
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 /**
  * Fetch design doc content from the backend API


### PR DESCRIPTION
## Summary

- Replace hardcoded `localhost:3008` fallback with empty string (relative URL) in all 4 frontend API files
- Update "Tauri backend" error message to deployment-agnostic "backend server"
- Make `dolt_host()`/`dolt_port()` pub, use actual env values in log messages instead of hardcoded port
- Add `NO_BROWSER=1` env var to suppress browser auto-open in Docker/headless deployments
- Bump version to 0.9.3 (sync Cargo.toml + package.json)
- Update `.env.local.example` with relative URL default

## Root Cause

Frontend `API_BASE` fell back to `http://localhost:3008` - a Tauri-era default. When accessing remotely (e.g. `http://144.124.255.40:9090`), the browser tried to fetch from `localhost:3008` on the user's machine, which failed with "Failed to fetch".

Since the Rust binary serves both frontend AND API on the same port, relative URLs (empty string) work for all scenarios: desktop, Docker, local dev, reverse proxy.

## Files Changed (10)

**Frontend (5):**
- `src/lib/api.ts` - API_BASE fallback + comment
- `src/lib/design-doc.ts` - API_BASE fallback
- `src/components/design-doc-viewer.tsx` - API_BASE fallback
- `src/components/update-banner.tsx` - health check URL
- `src/app/page.tsx` - error message text

**Backend (3):**
- `server/src/dolt.rs` - pub visibility + 2 unit tests
- `server/src/main.rs` - env-aware Dolt log + NO_BROWSER
- `server/Cargo.toml` - version 0.9.3

**Config (2):**
- `package.json` - version 0.9.3
- `.env.local.example` - updated defaults

## Test Plan

- [x] `grep -rn "localhost:3008" src/` returns no matches
- [x] `grep -rn "Tauri" src/` returns no runtime matches
- [ ] `cargo check` compiles
- [ ] `cargo test` passes (including 2 new dolt default tests)
- [ ] `npm run build` succeeds
- [ ] Manual: `PORT=9090 NO_BROWSER=1 ./target/release/beads-web` - projects load at localhost:9090

🤖 Generated with [Claude Code](https://claude.com/claude-code)