### PR TITLE
fix(hooks): replace removed 'bd sync --flush-only' with 'bd export' (bd 1.0.2)

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -46,9 +46,9 @@ if command -v bd >/dev/null 2>&1; then
   fi
 
   if [ -n "$BEADS_DIR" ]; then
-    if ! bd sync --flush-only >/dev/null 2>&1; then
+    if ! bd export -o "$BEADS_DIR/issues.jsonl" >/dev/null 2>&1; then
       echo "Error: Failed to flush bd changes to JSONL" >&2
-      echo "Run 'bd sync --flush-only' manually to diagnose" >&2
+      echo "Run 'bd export -o .beads/issues.jsonl' manually to diagnose" >&2
       exit 1
     fi
     if [ -f "$BEADS_DIR/issues.jsonl" ]; then


### PR DESCRIPTION
## Summary
Fixes bead **beads-web-mo4**. `scripts/install-hooks.sh` generated a pre-commit hook calling `bd sync --flush-only`, which was removed in bd v1.0.2 — every commit failed the hook without `--no-verify`. Replaced with `bd export -o "$BEADS_DIR/issues.jsonl"`, the v1.0.2 equivalent (synchronous flush of Dolt state to JSONL).

## Verification
- Regenerated hook via `npm run prepare`.
- Test commit without `--no-verify` succeeded end-to-end.

## Diff
`scripts/install-hooks.sh` — 2 lines changed.