### PR TITLE
feat(ui): prominent migrate-to-Dolt notice on JSONL project cards

### DIFF
--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -23,6 +23,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useToast } from "@/hooks/use-toast";
 import * as api from "@/lib/api";
 import type { Tag } from "@/lib/db";
+import { deriveBeadPrefix } from "@/lib/utils";
 import type { BeadCounts } from "@/types";
 
 /**
@@ -198,13 +199,41 @@ export function ProjectCard({
               Archived
             </span>
           )}
-          {!archivedAt && dataSource && (
+          {!archivedAt && dataSource === 'jsonl' && (
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex shrink-0 items-center gap-1 rounded-full border border-warning/40 bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    role="note"
+                    tabIndex={0}
+                    aria-label={`Old beads format — migrate with bd init --prefix ${deriveBeadPrefix(path, name)}`}
+                  >
+                    <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                    Old format — migrate
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs">
+                  <div className="space-y-1">
+                    <p className="text-xs">
+                      This project uses the old JSONL beads format. Run this in the project directory to migrate to Dolt:
+                    </p>
+                    <code className="block rounded bg-black/30 px-1.5 py-1 font-mono text-[11px]">
+                      bd init --prefix {deriveBeadPrefix(path, name)}
+                    </code>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          {!archivedAt && dataSource && dataSource !== 'jsonl' && (
             <span className="inline-flex shrink-0 items-center rounded-full bg-surface-overlay px-2 py-0.5 text-[10px] font-medium text-t-muted">
               {dataSource === 'dolt-project' ? 'Dolt (project)' :
                dataSource === 'dolt-central' ? 'Dolt (central)' :
                dataSource === 'dolt-direct' ? 'Dolt (direct)' :
-               dataSource === 'cli' ? 'CLI' :
-               dataSource === 'jsonl' ? 'JSONL' : dataSource}
+               dataSource === 'cli' ? 'CLI' : dataSource}
             </span>
           )}
         </div>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveBeadPrefix, isDoltProject } from './utils';
+
+describe('isDoltProject', () => {
+  it('returns true for dolt:// paths', () => {
+    expect(isDoltProject('dolt://foo')).toBe(true);
+  });
+
+  it('returns false for regular paths', () => {
+    expect(isDoltProject('M:/repos/foo')).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isDoltProject(null)).toBe(false);
+    expect(isDoltProject(undefined)).toBe(false);
+  });
+});
+
+describe('deriveBeadPrefix', () => {
+  it('derives slug from Windows-style path basename', () => {
+    expect(deriveBeadPrefix('M:/repos/foo-bar', 'ignored')).toBe('foo-bar');
+  });
+
+  it('derives slug from POSIX path basename and lowercases it', () => {
+    expect(deriveBeadPrefix('/home/user/MyProject', 'ignored')).toBe('myproject');
+  });
+
+  it('handles backslash-only paths (Windows native)', () => {
+    expect(deriveBeadPrefix('M:\\repos\\Foo_Bar', 'ignored')).toBe('foo-bar');
+  });
+
+  it('replaces non-alphanumeric with dashes and trims them', () => {
+    expect(deriveBeadPrefix('/tmp/--weird!!name--', 'ignored')).toBe('weird-name');
+  });
+
+  it('falls back to name when path is dolt://', () => {
+    expect(deriveBeadPrefix('dolt://whatever', 'My Project')).toBe('my-project');
+  });
+
+  it('falls back to name when path is empty', () => {
+    expect(deriveBeadPrefix('', 'FallbackName')).toBe('fallbackname');
+  });
+
+  it('returns empty string when nothing usable is provided', () => {
+    expect(deriveBeadPrefix('', '')).toBe('');
+  });
+
+  it('collapses multiple separators into a single dash', () => {
+    expect(deriveBeadPrefix('/path/to/foo   bar___baz', 'x')).toBe('foo-bar-baz');
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,3 +18,21 @@ export function cn(...inputs: ClassValue[]): string {
 export function isDoltProject(path: string | null | undefined): boolean {
   return !!path && path.startsWith("dolt://");
 }
+
+/**
+ * Derive a `bd init --prefix <slug>` slug from a project path (or name fallback).
+ *
+ * Rules:
+ *  - If `path` is a `dolt://` URL or empty, fall back to `name`.
+ *  - Otherwise take the last path segment (splitting on both `/` and `\`).
+ *  - Lowercase, replace any non-alphanumeric run with a single dash, trim dashes.
+ */
+export function deriveBeadPrefix(path: string, name: string): string {
+  const isDolt = path.startsWith("dolt://");
+  const lastSegment = path.split(/[\\/]/).filter(Boolean).pop();
+  const base = !path || isDolt ? name : (lastSegment ?? name);
+  return base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}


### PR DESCRIPTION
## Summary
Fixes bead **beads-web-532**. Replaced the subtle "JSONL" pill on JSONL-sourced project cards with a prominent amber warning chip (AlertTriangle icon + "Old format — migrate") that surfaces the exact `bd init --prefix <slug>` command via tooltip, where `<slug>` is derived from the project path basename.

## Changes
- `src/components/project-card.tsx` — jsonl branch renders a Tooltip-wrapped warning chip with the migration command in a `<code>` block.
- `src/lib/utils.ts` — new `deriveBeadPrefix(path, name)` helper.
- `src/lib/utils.test.ts` — 11 unit tests for the new helper.

Non-JSONL projects keep their existing neutral pill unchanged.

## Test plan
- [x] `npm run test` — 11 new green tests.
- [x] `npm run lint` — no new violations.
- [x] `npm run typecheck` — no new errors.
- [ ] Visual smoke on a JSONL-sourced project (reviewer — no JSONL projects in author's local setup).