### PR TITLE
feat(backend): cache per-project bead counts in SQLite (epic a9r, 1/2)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beads-server"
-version = "0.8.1"
+version = "0.9.1"
 dependencies = [
  "axum",
  "chrono",

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -68,6 +68,26 @@ pub struct Tag {
     pub color: String,
 }
 
+/// Cached per-project bead counts by status.
+///
+/// Populated on every successful `/api/beads` read and consumed by
+/// `/api/projects` so the home page can render donut charts without
+/// waiting on a full beads fetch.
+///
+/// Note: the `inreview` column is kept even though bd 1.0.2 removed the
+/// built-in status — users may define a custom `status.custom=inreview`
+/// via `.beads/config.yaml` and we preserve compat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedCounts {
+    pub open: i64,
+    pub in_progress: i64,
+    pub inreview: i64,
+    pub closed: i64,
+    pub data_source: Option<String>,
+    pub updated_at: String,
+}
+
 /// Input for creating a new project
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -150,6 +170,10 @@ impl Database {
     fn init_schema(&self) -> Result<(), DbError> {
         let conn = self.conn.lock().unwrap();
 
+        // Enable foreign key enforcement so ON DELETE CASCADE works.
+        // SQLite defaults foreign_keys=OFF per connection.
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+
         // Base schema (v0 — initial tables)
         conn.execute_batch(
             r"
@@ -205,6 +229,18 @@ impl Database {
         let migrations: Vec<(i64, &str)> = vec![
             (1, "ALTER TABLE projects ADD COLUMN local_path TEXT"),
             (2, "ALTER TABLE projects ADD COLUMN archived_at TEXT"),
+            (
+                3,
+                "CREATE TABLE IF NOT EXISTS project_bead_counts (
+                    project_id TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+                    open INTEGER NOT NULL DEFAULT 0,
+                    in_progress INTEGER NOT NULL DEFAULT 0,
+                    inreview INTEGER NOT NULL DEFAULT 0,
+                    closed INTEGER NOT NULL DEFAULT 0,
+                    data_source TEXT,
+                    updated_at TEXT NOT NULL
+                )",
+            ),
         ];
 
         let now = Utc::now().to_rfc3339();
@@ -395,6 +431,106 @@ impl Database {
         if rows == 0 {
             return Err(DbError::ProjectNotFound(id.to_string()));
         }
+        Ok(())
+    }
+
+    /// Looks up a project by its `path` column.
+    ///
+    /// Returns `Ok(None)` when no project matches (not an error — the caller
+    /// may be handling a `dolt://` path or a path unknown to the local DB).
+    ///
+    /// On Windows the `projects` table may hold paths with backslashes while
+    /// the `/api/beads` handler normalizes incoming paths to forward slashes,
+    /// so we match both the exact path and the backslash-swapped variant.
+    pub fn get_project_by_path(&self, path: &str) -> Result<Option<Project>, DbError> {
+        let conn = self.conn.lock().unwrap();
+        let alt_path = path.replace('/', "\\");
+        let row = conn.query_row(
+            "SELECT id, name, path, local_path, last_opened, created_at, archived_at
+             FROM projects WHERE path = ?1 OR path = ?2",
+            params![path, alt_path],
+            |row| {
+                Ok(Project {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    path: row.get(2)?,
+                    local_path: row.get(3)?,
+                    last_opened: row.get(4)?,
+                    created_at: row.get(5)?,
+                    archived_at: row.get(6)?,
+                })
+            },
+        );
+
+        match row {
+            Ok(project) => Ok(Some(project)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(DbError::Sqlite(e)),
+        }
+    }
+
+    // ===== Cached bead counts =====
+
+    /// Reads the cached bead counts for a project.
+    ///
+    /// Returns `Ok(None)` when no cache row exists yet (e.g. the project was
+    /// just created and `/api/beads` has not been called for it).
+    pub fn get_cached_counts(&self, project_id: &str) -> Result<Option<CachedCounts>, DbError> {
+        let conn = self.conn.lock().unwrap();
+        let row = conn.query_row(
+            "SELECT open, in_progress, inreview, closed, data_source, updated_at
+             FROM project_bead_counts WHERE project_id = ?1",
+            params![project_id],
+            |row| {
+                Ok(CachedCounts {
+                    open: row.get(0)?,
+                    in_progress: row.get(1)?,
+                    inreview: row.get(2)?,
+                    closed: row.get(3)?,
+                    data_source: row.get(4)?,
+                    updated_at: row.get(5)?,
+                })
+            },
+        );
+
+        match row {
+            Ok(counts) => Ok(Some(counts)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(DbError::Sqlite(e)),
+        }
+    }
+
+    /// Upserts cached bead counts for a project.
+    ///
+    /// Inserts a new row if none exists, otherwise replaces all fields.
+    /// Caller is expected to populate `updated_at` with a fresh timestamp.
+    pub fn upsert_cached_counts(
+        &self,
+        project_id: &str,
+        counts: &CachedCounts,
+    ) -> Result<(), DbError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO project_bead_counts
+                (project_id, open, in_progress, inreview, closed, data_source, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(project_id) DO UPDATE SET
+                open = excluded.open,
+                in_progress = excluded.in_progress,
+                inreview = excluded.inreview,
+                closed = excluded.closed,
+                data_source = excluded.data_source,
+                updated_at = excluded.updated_at",
+            params![
+                project_id,
+                counts.open,
+                counts.in_progress,
+                counts.inreview,
+                counts.closed,
+                counts.data_source,
+                counts.updated_at,
+            ],
+        )?;
         Ok(())
     }
 
@@ -694,5 +830,168 @@ mod tests {
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].tags.len(), 1);
         assert_eq!(projects[0].tags[0].name, "Tag1");
+    }
+
+    // ── get_project_by_path ──────────────────────────────────────────
+
+    #[test]
+    fn test_get_project_by_path_found() {
+        let db = Database::new_in_memory().unwrap();
+        let created = db
+            .create_project(CreateProjectInput {
+                name: "Lookup".to_string(),
+                path: "/lookup/by/path".to_string(),
+                local_path: None,
+            })
+            .unwrap();
+
+        let found = db.get_project_by_path("/lookup/by/path").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, created.id);
+    }
+
+    #[test]
+    fn test_get_project_by_path_not_found() {
+        let db = Database::new_in_memory().unwrap();
+        let found = db.get_project_by_path("/does/not/exist").unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_get_project_by_path_matches_windows_backslash_variant() {
+        // Project created with backslashes (as Windows frontends might send)
+        // should still match when the caller passes the forward-slash variant
+        // that `/api/beads` normalizes to before looking up.
+        let db = Database::new_in_memory().unwrap();
+        let created = db
+            .create_project(CreateProjectInput {
+                name: "Win".to_string(),
+                path: "M:\\repos\\win\\project".to_string(),
+                local_path: None,
+            })
+            .unwrap();
+
+        let found = db.get_project_by_path("M:/repos/win/project").unwrap();
+        assert!(found.is_some(), "forward-slash lookup should match backslash-stored path");
+        assert_eq!(found.unwrap().id, created.id);
+    }
+
+    // ── cached bead counts ──────────────────────────────────────────
+
+    #[test]
+    fn test_cached_counts_insert_and_get() {
+        let db = Database::new_in_memory().unwrap();
+        let project = db
+            .create_project(CreateProjectInput {
+                name: "Counts".to_string(),
+                path: "/counts".to_string(),
+                local_path: None,
+            })
+            .unwrap();
+
+        // Initially no cache row
+        let initial = db.get_cached_counts(&project.id).unwrap();
+        assert!(initial.is_none(), "expected no cache row before first upsert");
+
+        let counts = CachedCounts {
+            open: 3,
+            in_progress: 1,
+            inreview: 0,
+            closed: 7,
+            data_source: Some("cli".to_string()),
+            updated_at: "2026-04-22T10:00:00Z".to_string(),
+        };
+        db.upsert_cached_counts(&project.id, &counts).unwrap();
+
+        let fetched = db.get_cached_counts(&project.id).unwrap().unwrap();
+        assert_eq!(fetched.open, 3);
+        assert_eq!(fetched.in_progress, 1);
+        assert_eq!(fetched.inreview, 0);
+        assert_eq!(fetched.closed, 7);
+        assert_eq!(fetched.data_source.as_deref(), Some("cli"));
+        assert_eq!(fetched.updated_at, "2026-04-22T10:00:00Z");
+    }
+
+    #[test]
+    fn test_cached_counts_upsert_replaces_existing() {
+        let db = Database::new_in_memory().unwrap();
+        let project = db
+            .create_project(CreateProjectInput {
+                name: "Upsert".to_string(),
+                path: "/upsert".to_string(),
+                local_path: None,
+            })
+            .unwrap();
+
+        let first = CachedCounts {
+            open: 10,
+            in_progress: 2,
+            inreview: 1,
+            closed: 0,
+            data_source: Some("jsonl".to_string()),
+            updated_at: "2026-04-22T10:00:00Z".to_string(),
+        };
+        db.upsert_cached_counts(&project.id, &first).unwrap();
+
+        let second = CachedCounts {
+            open: 8,
+            in_progress: 3,
+            inreview: 2,
+            closed: 5,
+            data_source: Some("dolt-direct".to_string()),
+            updated_at: "2026-04-22T11:00:00Z".to_string(),
+        };
+        db.upsert_cached_counts(&project.id, &second).unwrap();
+
+        let fetched = db.get_cached_counts(&project.id).unwrap().unwrap();
+        assert_eq!(fetched.open, 8);
+        assert_eq!(fetched.in_progress, 3);
+        assert_eq!(fetched.inreview, 2);
+        assert_eq!(fetched.closed, 5);
+        assert_eq!(fetched.data_source.as_deref(), Some("dolt-direct"));
+        assert_eq!(fetched.updated_at, "2026-04-22T11:00:00Z");
+
+        // Still only one row for this project
+        let conn = db.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM project_bead_counts WHERE project_id = ?1",
+                params![project.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_cached_counts_cascade_on_project_delete() {
+        let db = Database::new_in_memory().unwrap();
+        let project = db
+            .create_project(CreateProjectInput {
+                name: "Cascade".to_string(),
+                path: "/cascade".to_string(),
+                local_path: None,
+            })
+            .unwrap();
+
+        db.upsert_cached_counts(
+            &project.id,
+            &CachedCounts {
+                open: 1,
+                in_progress: 0,
+                inreview: 0,
+                closed: 0,
+                data_source: None,
+                updated_at: "2026-04-22T10:00:00Z".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert!(db.get_cached_counts(&project.id).unwrap().is_some());
+
+        db.delete_project(&project.id).unwrap();
+
+        // Cache row should be removed by ON DELETE CASCADE
+        assert!(db.get_cached_counts(&project.id).unwrap().is_none());
     }
 }

--- a/server/src/routes/beads.rs
+++ b/server/src/routes/beads.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use tokio::process::Command;
 
 use super::validate_path_security;
+use crate::db::{CachedCounts, Database};
 use crate::dolt::{self, DoltManager};
 
 /// Resolves the Dolt server port for a project.
@@ -290,6 +291,66 @@ fn extract_json_array(output: &str) -> Result<&str, String> {
     }
 }
 
+/// Computes bead counts from a slice of beads and upserts them into the
+/// local SQLite cache so the home page can render donut charts instantly.
+///
+/// Cache writes are best-effort — failures are logged but never propagated
+/// to the `/api/beads` response. The `project_path` is looked up against
+/// the `projects` table; if no matching project exists (e.g. `dolt://`
+/// paths or paths unknown to the local DB), the cache is skipped.
+fn upsert_counts_cache(
+    db: &Database,
+    project_path: &str,
+    data_source: &str,
+    beads: &[Bead],
+) {
+    let project = match db.get_project_by_path(project_path) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            tracing::debug!(
+                "No project row for path {}, skipping counts cache",
+                project_path
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!("Failed to look up project by path {}: {}", project_path, e);
+            return;
+        }
+    };
+
+    let mut open = 0i64;
+    let mut in_progress = 0i64;
+    let mut inreview = 0i64;
+    let mut closed = 0i64;
+    for bead in beads {
+        match bead.status.as_str() {
+            "open" => open += 1,
+            "in_progress" => in_progress += 1,
+            "inreview" => inreview += 1,
+            "closed" => closed += 1,
+            _ => {}
+        }
+    }
+
+    let counts = CachedCounts {
+        open,
+        in_progress,
+        inreview,
+        closed,
+        data_source: Some(data_source.to_string()),
+        updated_at: Utc::now().to_rfc3339(),
+    };
+
+    if let Err(e) = db.upsert_cached_counts(&project.id, &counts) {
+        tracing::warn!(
+            "Failed to upsert cached counts for project {}: {}",
+            project.id,
+            e
+        );
+    }
+}
+
 /// Reads beads from the Dolt database via `bd` CLI.
 ///
 /// Calls `bd list --json` for issues and `bd sql` for comments,
@@ -376,8 +437,13 @@ const DOLT_PATH_PREFIX: &str = "dolt://";
 ///
 /// Reads beads from a project. For `dolt://` paths, reads directly from Dolt SQL.
 /// For filesystem paths, uses three-tier fallback: Dolt SQL → bd CLI → JSONL.
+///
+/// On every successful read, the computed per-status bead counts are upserted
+/// into the local SQLite cache (`project_bead_counts`) so `/api/projects` can
+/// return them for instant home-page rendering. Cache writes are best-effort.
 pub async fn read_beads(
     Extension(dolt_manager): Extension<Arc<DoltManager>>,
+    Extension(db): Extension<Arc<Database>>,
     Query(params): Query<BeadsParams>,
 ) -> impl IntoResponse {
     // Normalize Windows backslashes to forward slashes
@@ -394,6 +460,7 @@ pub async fn read_beads(
         return match dolt_manager.read_beads(db_name).await {
             Ok(beads) => {
                 let beads = post_process_beads(beads);
+                upsert_counts_cache(&db, &path, "dolt-direct", &beads);
                 (StatusCode::OK, Json(serde_json::json!({ "beads": beads, "source": "dolt-direct" })))
             }
             Err(e) => (
@@ -446,6 +513,7 @@ pub async fn read_beads(
                     Ok(beads) => {
                         tracing::info!("Read {} beads from per-project Dolt (port {})", beads.len(), port);
                         let beads = post_process_beads(beads);
+                        upsert_counts_cache(&db, &path, "dolt-project", &beads);
                         return (StatusCode::OK, Json(serde_json::json!({ "beads": beads, "source": "dolt-project" })));
                     }
                     Err(e) => {
@@ -508,6 +576,7 @@ pub async fn read_beads(
     };
 
     let beads = post_process_beads(beads);
+    upsert_counts_cache(&db, &path, source, &beads);
     (StatusCode::OK, Json(serde_json::json!({ "beads": beads, "source": source })))
 }
 

--- a/server/src/routes/projects.rs
+++ b/server/src/routes/projects.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::db::{
-    CreateProjectInput, CreateTagInput, Database, DbError, ProjectTagInput, ProjectWithTags, Tag,
-    UpdateProjectInput,
+    CachedCounts, CreateProjectInput, CreateTagInput, Database, DbError, ProjectTagInput,
+    ProjectWithTags, Tag, UpdateProjectInput,
 };
 
 /// Application state containing the database
@@ -57,11 +57,22 @@ pub struct ListProjectsParams {
     pub include_archived: Option<bool>,
 }
 
-/// GET /api/projects - List all projects with their tags
+/// A project list entry — `ProjectWithTags` flattened with the cached
+/// bead counts attached. The `cachedCounts` field is `null` until
+/// `/api/beads` has been called for the project at least once.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectWithTagsAndCounts {
+    #[serde(flatten)]
+    pub project: ProjectWithTags,
+    pub cached_counts: Option<CachedCounts>,
+}
+
+/// GET /api/projects - List all projects with their tags and cached bead counts
 pub async fn list_projects(
     State(db): State<AppState>,
     Query(params): Query<ListProjectsParams>,
-) -> Result<Json<Vec<ProjectWithTags>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<Vec<ProjectWithTagsAndCounts>>, (StatusCode, Json<ErrorResponse>)> {
     let include_archived = params.include_archived.unwrap_or(false);
     let mut projects = db.get_projects_with_tags_filtered(include_archived).map_err(db_error_response)?;
     // Normalize Windows backslashes in paths for consistent frontend behavior
@@ -71,7 +82,29 @@ pub async fn list_projects(
             p.local_path = Some(lp.replace('\\', "/"));
         }
     }
-    Ok(Json(projects))
+
+    let mut result = Vec::with_capacity(projects.len());
+    for project in projects {
+        // Cache reads are best-effort — log and fall back to None on error
+        // so a single corrupt row can't block the whole projects list.
+        let cached_counts = match db.get_cached_counts(&project.id) {
+            Ok(counts) => counts,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to read cached counts for project {}: {}",
+                    project.id,
+                    e
+                );
+                None
+            }
+        };
+        result.push(ProjectWithTagsAndCounts {
+            project,
+            cached_counts,
+        });
+    }
+
+    Ok(Json(result))
 }
 
 /// POST /api/projects - Create a new project
@@ -212,4 +245,65 @@ pub fn project_routes() -> axum::Router<AppState> {
         // Project-tag relationship routes
         .route("/project-tags", post(add_project_tag))
         .route("/project-tags/:project_id/:tag_id", delete(remove_project_tag))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_project_with_tags() -> ProjectWithTags {
+        ProjectWithTags {
+            id: "proj-1".to_string(),
+            name: "Sample".to_string(),
+            path: "/sample".to_string(),
+            local_path: None,
+            tags: vec![],
+            last_opened: "2026-04-22T10:00:00Z".to_string(),
+            created_at: "2026-04-22T09:00:00Z".to_string(),
+            archived_at: None,
+        }
+    }
+
+    #[test]
+    fn test_project_with_counts_serializes_camel_case_and_flattens() {
+        let entry = ProjectWithTagsAndCounts {
+            project: make_project_with_tags(),
+            cached_counts: Some(CachedCounts {
+                open: 3,
+                in_progress: 1,
+                inreview: 0,
+                closed: 2,
+                data_source: Some("cli".to_string()),
+                updated_at: "2026-04-22T10:00:00Z".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+
+        // Flattened fields preserve ProjectWithTags' camelCase rename
+        assert!(json.contains("\"lastOpened\":\"2026-04-22T10:00:00Z\""));
+        assert!(json.contains("\"createdAt\":\"2026-04-22T09:00:00Z\""));
+        assert!(json.contains("\"localPath\":null"));
+        assert!(json.contains("\"archivedAt\":null"));
+
+        // cachedCounts wrapper is camelCase
+        assert!(json.contains("\"cachedCounts\":{"));
+        // CachedCounts inner fields are camelCase
+        assert!(json.contains("\"inProgress\":1"));
+        assert!(json.contains("\"dataSource\":\"cli\""));
+        assert!(json.contains("\"updatedAt\":\"2026-04-22T10:00:00Z\""));
+        // No snake_case leaks
+        assert!(!json.contains("\"in_progress\""));
+        assert!(!json.contains("\"data_source\""));
+        assert!(!json.contains("\"cached_counts\""));
+    }
+
+    #[test]
+    fn test_project_with_counts_serializes_null_when_no_cache() {
+        let entry = ProjectWithTagsAndCounts {
+            project: make_project_with_tags(),
+            cached_counts: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"cachedCounts\":null"));
+    }
 }


### PR DESCRIPTION
## Summary
Part of epic **beads-web-a9r**. Adds a SQLite cache of per-status bead counts so the home page can render donuts without waiting for a full beads read. **Backend only** — frontend consumption follows in `a9r.2`.

## Changes
- `server/src/db.rs`:
  - Migration v3 creates `project_bead_counts` (`project_id` PK FK, `open`/`in_progress`/`inreview`/`closed`, `data_source`, `updated_at`) with `ON DELETE CASCADE`.
  - `PRAGMA foreign_keys = ON` enabled so cascade fires.
  - New struct `CachedCounts` (camelCase serde).
  - New methods: `get_cached_counts`, `upsert_cached_counts` (INSERT … ON CONFLICT), `get_project_by_path` (handles Windows `\` / POSIX `/`).
- `server/src/routes/beads.rs`: every `/api/beads` success path now upserts counts via a single `upsert_counts_cache` helper. Failures logged via `tracing::warn!`, never fail the response.
- `server/src/routes/projects.rs`: list returns `ProjectWithTagsAndCounts` (`#[serde(flatten)]` over `ProjectWithTags` + `cachedCounts: Option<CachedCounts>`). Existing `ProjectWithTags` shape unchanged.

## Test plan
- [x] `cargo test` — 153/153 pass (+8 new).
- [x] `cargo build --release` — clean.
- [ ] Reviewer confirms `ProjectWithTagsAndCounts` serde shape satisfies the `a9r.2` frontend contract.

## Follow-up
- `a9r.2` (blocked on this) — frontend uses `cachedCounts` for instant initial render.