### PR TITLE
feat(frontend): instant donut paint via cached bead counts (epic a9r, 2/2)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -246,6 +246,7 @@ export default function ProjectsPage() {
                   localPath={project.localPath}
                   tags={project.tags}
                   beadCounts={project.beadCounts}
+                  countsLoaded={project.countsLoaded ?? false}
                   dataSource={project.dataSource}
                   beadError={project.beadError}
                   archivedAt={project.archivedAt}

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -7,7 +7,6 @@ import { useRouter } from "next/navigation";
 import { AlertTriangle, Archive, ArchiveRestore, Code, FolderOpen, Loader2, Settings } from "lucide-react";
 
 import { ProjectSettingsDialog } from "@/components/project-settings-dialog";
-
 import { StatusDonut } from "@/components/status-donut";
 import { TagPicker } from "@/components/tag-picker";
 import { Badge } from "@/components/ui/badge";
@@ -54,6 +53,12 @@ interface ProjectCardProps {
   localPath?: string;
   tags: Tag[];
   beadCounts?: BeadCounts;
+  /**
+   * True once `beadCounts` reflects either cached or freshly-fetched
+   * data. When false, the card renders a dashed placeholder donut so
+   * the user never sees misleading zeros on first paint.
+   */
+  countsLoaded?: boolean;
   dataSource?: string;
   beadError?: string;
   archivedAt?: string;
@@ -71,6 +76,7 @@ export function ProjectCard({
   localPath,
   tags,
   beadCounts = { open: 0, in_progress: 0, inreview: 0, closed: 0 },
+  countsLoaded = true,
   dataSource,
   beadError,
   archivedAt,
@@ -149,7 +155,7 @@ export function ProjectCard({
             </Tooltip>
           </TooltipProvider>
         ) : (
-          <StatusDonut beadCounts={beadCounts} size={36} />
+          <StatusDonut beadCounts={beadCounts} size={36} countsLoaded={countsLoaded} />
         )}
         <div
           className="flex flex-wrap items-center gap-1.5"

--- a/src/components/status-donut.tsx
+++ b/src/components/status-donut.tsx
@@ -13,6 +13,13 @@ interface StatusDonutProps {
   beadCounts: BeadCounts;
   size?: number;
   className?: string;
+  /**
+   * When `false`, renders a dashed/outline placeholder donut regardless
+   * of the numeric counts. Used on the home page to signal "counts are
+   * still loading from the backend, no cached value yet" without
+   * showing a misleading "0 tasks" state.
+   */
+  countsLoaded?: boolean;
 }
 
 // Status colors via CSS variables (semantic tokens from globals.css)
@@ -64,7 +71,7 @@ function StatusTooltip({ beadCounts, total }: { beadCounts: BeadCounts; total: n
   );
 }
 
-export function StatusDonut({ beadCounts, size = 40, className }: StatusDonutProps) {
+export function StatusDonut({ beadCounts, size = 40, className, countsLoaded = true }: StatusDonutProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   const chartData = useMemo(() => {
@@ -80,17 +87,22 @@ export function StatusDonut({ beadCounts, size = 40, className }: StatusDonutPro
     return beadCounts.open + beadCounts.in_progress + beadCounts.inreview + beadCounts.closed;
   }, [beadCounts]);
 
-  // If no tasks, show empty state
-  if (total === 0) {
+  // Dashed placeholder when counts haven't loaded yet, OR when the
+  // project genuinely has no tasks. Same visual — the former resolves
+  // to a solid donut on its own once `countsLoaded` flips to true, the
+  // latter stays dashed indefinitely which is correct semantics.
+  if (!countsLoaded || total === 0) {
+    const label = !countsLoaded ? "Loading tasks" : "No tasks";
     return (
       <div
         className={className}
         style={{ width: size, height: size }}
-        aria-label="No tasks"
+        aria-label={label}
+        aria-busy={!countsLoaded}
       >
         <div
           className="rounded-full border-2 border-dashed border-b-strong w-full h-full"
-          title="No tasks"
+          title={label}
         />
       </div>
     );

--- a/src/hooks/__tests__/use-projects.test.tsx
+++ b/src/hooks/__tests__/use-projects.test.tsx
@@ -1,0 +1,128 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { Project } from '@/types';
+
+// --- Mocks ------------------------------------------------------------------
+//
+// `useProjects` composes two dependencies:
+//   - `getProjectsWithTags` (src/lib/db) — returns the project list with
+//     `cachedCounts` attached by the backend.
+//   - `loadProjectBeads` (src/lib/beads-parser) — fetches fresh beads per
+//     project and normally overwrites the cached seed.
+//
+// We mock both. `loadProjectBeads` is made to never resolve so the hook
+// stays in the "cached seed only" state and we can assert the initial
+// render uses the cached counts, not zeros.
+
+const getProjectsWithTagsMock = vi.fn();
+const loadProjectBeadsMock = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  getProjectsWithTags: (...args: unknown[]) => getProjectsWithTagsMock(...args),
+  createProject: vi.fn(),
+}));
+
+vi.mock('@/lib/beads-parser', () => ({
+  loadProjectBeads: (...args: unknown[]) => loadProjectBeadsMock(...args),
+  // Not called in these tests because loadProjectBeads never resolves, but
+  // keep a stub so importers don't crash.
+  groupBeadsByStatus: vi.fn(() => ({
+    open: [],
+    in_progress: [],
+    inreview: [],
+    closed: [],
+  })),
+}));
+
+vi.mock('@/lib/api', () => ({
+  projects: {
+    archive: vi.fn(),
+    unarchive: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Import AFTER mocks so the hook picks them up.
+// eslint-disable-next-line import/first, import/order
+import { useProjects } from '../use-projects';
+
+beforeEach(() => {
+  getProjectsWithTagsMock.mockReset();
+  loadProjectBeadsMock.mockReset();
+  // Never resolve — lets us observe the cached-seed state in isolation.
+  loadProjectBeadsMock.mockImplementation(() => new Promise(() => {}));
+});
+
+describe('useProjects — cached counts seeding', () => {
+  it('seeds beadCounts from server cachedCounts on initial render', async () => {
+    const project: Project = {
+      id: 'p1',
+      name: 'cached-project',
+      path: '/tmp/cached-project',
+      tags: [],
+      lastOpened: '2026-04-22T00:00:00Z',
+      createdAt: '2026-04-22T00:00:00Z',
+      cachedCounts: {
+        open: 3,
+        in_progress: 1,
+        inreview: 0,
+        closed: 5,
+        dataSource: 'dolt-direct',
+        updatedAt: '2026-04-22T00:00:00Z',
+      },
+    };
+
+    getProjectsWithTagsMock.mockResolvedValueOnce([project]);
+
+    const { result } = renderHook(() => useProjects());
+
+    // Wait for the fetch to populate state. `isLoading` flips to false
+    // right after the seed step, before beads fetching starts.
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.projects).toHaveLength(1);
+    const seeded = result.current.projects[0];
+    expect(seeded.beadCounts).toEqual({
+      open: 3,
+      in_progress: 1,
+      inreview: 0,
+      closed: 5,
+    });
+    expect(seeded.countsLoaded).toBe(true);
+    expect(seeded.dataSource).toBe('dolt-direct');
+  });
+
+  it('leaves countsLoaded false when no cache exists, so donut renders as dashed', async () => {
+    const project: Project = {
+      id: 'p2',
+      name: 'fresh-project',
+      path: '/tmp/fresh-project',
+      tags: [],
+      lastOpened: '2026-04-22T00:00:00Z',
+      createdAt: '2026-04-22T00:00:00Z',
+      cachedCounts: null,
+    };
+
+    getProjectsWithTagsMock.mockResolvedValueOnce([project]);
+
+    const { result } = renderHook(() => useProjects());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const seeded = result.current.projects[0];
+    expect(seeded.countsLoaded).toBe(false);
+    // Zero counts are a fallback — NOT a real "0 tasks" signal. The
+    // dashed donut rendering in project-card distinguishes these.
+    expect(seeded.beadCounts).toEqual({
+      open: 0,
+      in_progress: 0,
+      inreview: 0,
+      closed: 0,
+    });
+  });
+});

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -2,8 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 
-import { loadProjectBeads, groupBeadsByStatus } from "@/lib/beads-parser";
 import * as api from "@/lib/api";
+import { loadProjectBeads, groupBeadsByStatus } from "@/lib/beads-parser";
 import {
   getProjectsWithTags,
   createProject,
@@ -54,15 +54,46 @@ export function useProjects(): UseProjectsResult {
       const data = await getProjectsWithTags(showArchivedRef.current);
       if (loadId !== loadingRef.current) return;
 
-      // Show projects immediately, preserving existing bead counts from previous load
+      // Show projects immediately. Seed bead counts from (in priority order):
+      //   1. The previous in-memory project (covers live refreshes).
+      //   2. The server-provided `cachedCounts` from the SQLite cache
+      //      (covers cold loads — instant donut paint).
+      //   3. `zeroCounts` as a last-resort empty state. In that case
+      //      `countsLoaded` stays false so the card can render a dashed
+      //      placeholder donut instead of misleading "0/0/0/0" values.
       const zeroCounts: BeadCounts = { open: 0, in_progress: 0, inreview: 0, closed: 0 };
       setProjects((prev) => {
         const prevMap = new Map(prev.map((p) => [p.id, p]));
-        return data.map((p) => ({
-          ...p,
-          beadCounts: prevMap.get(p.id)?.beadCounts ?? zeroCounts,
-          dataSource: prevMap.get(p.id)?.dataSource,
-        }));
+        return data.map((p) => {
+          const prevProject = prevMap.get(p.id);
+          const cached = p.cachedCounts ?? null;
+
+          // Prefer previous in-memory counts (freshest), then server cache.
+          const hasPrev = prevProject?.beadCounts !== undefined && prevProject.countsLoaded === true;
+          const beadCounts: BeadCounts = hasPrev
+            ? prevProject!.beadCounts!
+            : cached
+              ? {
+                  open: cached.open,
+                  in_progress: cached.in_progress,
+                  inreview: cached.inreview,
+                  closed: cached.closed,
+                }
+              : zeroCounts;
+
+          const dataSource = hasPrev
+            ? prevProject!.dataSource
+            : cached?.dataSource ?? undefined;
+
+          const countsLoaded = hasPrev || cached !== null;
+
+          return {
+            ...p,
+            beadCounts,
+            dataSource: dataSource ?? undefined,
+            countsLoaded,
+          };
+        });
       });
       setIsLoading(false);
 
@@ -118,7 +149,15 @@ export function useProjects(): UseProjectsResult {
                 setProjects((prev) =>
                   prev.map((p) =>
                     p.id === result.id
-                      ? { ...p, beadCounts: result.beadCounts, dataSource: result.dataSource, beadError: result.beadError }
+                      ? {
+                          ...p,
+                          beadCounts: result.beadCounts,
+                          dataSource: result.dataSource,
+                          beadError: result.beadError,
+                          // Fresh data has landed — donut should switch from
+                          // dashed (if it was dashed) to solid.
+                          countsLoaded: true,
+                        }
                       : p
                   )
                 );

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -106,6 +106,7 @@ describe('api.version', () => {
       update_available: true,
       download_url: 'https://example.com',
       release_notes: 'New features',
+      asset_url: null,
     };
 
     mockFetch.mockResolvedValue(mockResponse(versionData));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,20 @@ export interface BeadCounts {
 }
 
 /**
+ * Cached per-project bead counts served by `GET /api/projects`.
+ *
+ * Populated by the backend after any successful `/api/beads` read and
+ * used by the home page to render donut charts immediately on first
+ * paint, before fresh counts finish loading.
+ */
+export interface CachedCounts extends BeadCounts {
+  /** Source that produced these cached counts (e.g. 'dolt-direct', 'jsonl'). */
+  dataSource?: string | null;
+  /** ISO-8601 timestamp of when the cache row was last refreshed. */
+  updatedAt: string;
+}
+
+/**
  * Project stored in local SQLite
  */
 export interface Project {
@@ -23,6 +37,19 @@ export interface Project {
   beadCounts?: BeadCounts;
   dataSource?: string;
   beadError?: string;
+  /**
+   * Cached counts payload from the server. Present on responses from
+   * `GET /api/projects` when a cache row exists, `null` for brand-new
+   * projects that have never been read yet. Consumed by `useProjects`
+   * to seed `beadCounts` on initial render for instant donut paint.
+   */
+  cachedCounts?: CachedCounts | null;
+  /**
+   * True once counts on this project have been seeded from either the
+   * server cache OR an in-memory previous load. False while we are
+   * showing an empty placeholder donut awaiting the first fetch.
+   */
+  countsLoaded?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Closes epic **beads-web-a9r** (part 2/2). Consumes the `cachedCounts` field added to `GET /api/projects` in #11 so the home page paints donut charts instantly from SQLite-cached values, then live-refreshes per project as fresh beads load.

## Changes
- `src/types/index.ts` — new `CachedCounts` type; `Project` gets `cachedCounts?: CachedCounts | null` and `countsLoaded?: boolean`.
- `src/hooks/use-projects.ts` — three-tier seed (prev in-memory → server cache → zeros). `countsLoaded` flag tracks authoritative state; fresh-fetch override flips it to `true`.
- `src/components/status-donut.tsx` — new `countsLoaded?: boolean` prop; dashed placeholder with `aria-busy` when false.
- `src/components/project-card.tsx` + `src/app/page.tsx` — wire `countsLoaded` through.
- `src/hooks/__tests__/use-projects.test.tsx` — new vitest suite (cache hit seeds real numbers; cache miss keeps `countsLoaded=false`).
- Drive-by: `src/lib/__tests__/api.test.ts` gets `asset_url: null` fixture fix to unblock pre-commit tsc.

## Shape note
Backend sends `dataSource` nested inside `cachedCounts`, not as a top-level `cachedDataSource`. Hook reads it from the nested struct.

## Test plan
- [x] `npm run test` — 2 new passing; no new regressions.
- [x] `npm run lint`, `npm run typecheck`, `npm run build` — clean.
- [ ] Visual smoke: dashed donut flips to solid after fresh load (reviewer — no browser session available in author's env).