### PR TITLE
chore(ci): bump actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -65,7 +65,7 @@ jobs:
         run: copy server\target\${{ matrix.target }}\release\beads-server.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 
@@ -89,7 +89,7 @@ jobs:
           ls -la release/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ inputs.version || github.ref_name }}
           tag_name: ${{ inputs.version || github.ref_name }}


### PR DESCRIPTION
Bumps CI actions in `release.yml` to versions supporting the Node 24 runtime that GitHub is migrating to starting 2026-06-02.

- actions/checkout v4 → v5
- actions/setup-node v4 → v5
- actions/upload-artifact v4 → v5
- actions/download-artifact v4 → v5
- softprops/action-gh-release v1 → v2

`node-version: '20'` input kept — that's the Node used by `npm` inside the job, separate from the runner Node.

Closes beads-web-htb