### PR TITLE
fix(bd-interop): stop stray issues.jsonl at worktree roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ next-env.d.ts
 AGENTS.md
 CLAUDE.md
 
+# Stray bd auto-export files (bd v1.0.2 CWD bug — see beads-web-b9c)
+/issues.jsonl
+
 # spec and test files
 SPEC.md
 test-*.md

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -14,6 +14,22 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# ── bd config: disable auto git-add (bd-beads-web-b9c) ────────────────
+# bd v1.0.2 auto-export runs `git add issues.jsonl` relative to CWD,
+# which creates stray files at worktree roots. Apply the config fix on
+# every `npm install` so new clones and CI pick it up automatically.
+# .beads/ is gitignored, so each checkout gets its own local config.yaml.
+# bd itself walks up to find .beads/, so we let bd's own resolver gate us:
+# if `bd config get` fails (no .beads/ found anywhere), skip silently.
+if command -v bd >/dev/null 2>&1; then
+  CURRENT_GIT_ADD="$(bd config get export.git-add 2>/dev/null || true)"
+  if [ -n "$CURRENT_GIT_ADD" ] && [ "$CURRENT_GIT_ADD" != "false" ]; then
+    if bd config set export.git-add false >/dev/null 2>&1; then
+      echo "bd config: export.git-add=false (prevents stray issues.jsonl in worktrees)"
+    fi
+  fi
+fi
+
 # For worktrees, hooks live in the common git dir
 HOOKS_DIR="$(git rev-parse --git-common-dir)/hooks"
 mkdir -p "$HOOKS_DIR"


### PR DESCRIPTION
bd v1.0.2 auto-export runs \`git add issues.jsonl\` relative to CWD, creating stray files at worktree roots on every \`bd comments add\` / \`bd update\` an agent runs.

Two-part fix:

1. \`.gitignore\`: root-anchored \`/issues.jsonl\` so stray files can never land in commits. Leading slash prevents shadowing of \`.beads/issues.jsonl\` (correct path, still covered by the existing \`.beads/\` rule).
2. \`scripts/install-hooks.sh\`: auto-apply \`bd config set export.git-add false\` on every \`npm install\` via the \`prepare\` lifecycle. Idempotent; silent-skips when bd is absent or no beads dir is found.

Closes beads-web-b9c