### PR TITLE
chore(ci): bump 3 actions to Node 24 runtime majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         run: copy server\target\${{ matrix.target }}\release\beads-server.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 
@@ -89,7 +89,7 @@ jobs:
           ls -la release/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ inputs.version || github.ref_name }}
           tag_name: ${{ inputs.version || github.ref_name }}


### PR DESCRIPTION
Follow-up to v0.10.1's CI annotation. The earlier htb bump moved five actions to what their release notes called "Node 24 support", but `upload-artifact@v5`, `download-artifact@v5`, and `action-gh-release@v2` actually still declare `using: node20` in their `action.yml` — marketing ≠ runtime.

This PR bumps the three laggards to majors where the `action.yml` `runs.using` field truly flips to `node24`:

- actions/upload-artifact v5 → v7
- actions/download-artifact v5 → v7
- softprops/action-gh-release v2 → v3

Verification will happen on the next release tag — annotations should be empty.

Closes beads-web-xhj