### PR TITLE
fix(ui): BLOCKED badge respects dep statuses

### DIFF
--- a/src/app/project/kanban-board.tsx
+++ b/src/app/project/kanban-board.tsx
@@ -294,7 +294,7 @@ export default function KanbanBoard() {
             <span className="uppercase">{project.name}_</span>
           </h1>
           <span className="font-mono text-xs text-t-muted uppercase tracking-widest">
-            {beads.length} beads // {beads.filter(b => b.issue_type === 'epic').length} epics // {beads.filter(b => isBlocked(b)).length} blocked
+            {beads.length} beads // {beads.filter(b => b.issue_type === 'epic').length} epics // {beads.filter(b => isBlocked(b, beads)).length} blocked
           </span>
         </div>
       ) : (

--- a/src/components/bead-card.tsx
+++ b/src/components/bead-card.tsx
@@ -11,6 +11,8 @@ import type { Bead, WorktreeStatus, PRStatus, StatusBadgeInfo } from "@/types";
 
 export interface BeadCardProps {
   bead: Bead;
+  /** All beads on the board, used to resolve dep statuses for blocked detection */
+  allBeads: Bead[];
   ticketNumber?: number;
   /** Worktree status for the bead */
   worktreeStatus?: WorktreeStatus;
@@ -144,9 +146,9 @@ function getStatusBadgeClasses(variant: StatusBadgeInfo['variant']): string {
   }
 }
 
-export function BeadCard({ bead, ticketNumber, worktreeStatus, prStatus, isSelected = false, onSelect }: BeadCardProps) {
+export function BeadCard({ bead, allBeads, ticketNumber, worktreeStatus, prStatus, isSelected = false, onSelect }: BeadCardProps) {
   const { layout } = useTheme();
-  const blocked = isBlocked(bead);
+  const blocked = isBlocked(bead, allBeads);
   const commentCount = (bead.comments ?? []).length;
   const relatedCount = (bead.relates_to ?? []).length;
 

--- a/src/components/dependency-badge.tsx
+++ b/src/components/dependency-badge.tsx
@@ -11,6 +11,16 @@ export interface DependencyBadgeProps {
   deps?: string[];
   /** Bead IDs that depend on this task (this task blocks them) */
   blockers?: string[];
+  /**
+   * Whether this task is currently blocked by unresolved dependencies.
+   * The parent decides this — typically by calling `isBlocked(bead, allBeads)`
+   * from `@/lib/bead-utils` so that closed deps don't count as blocking.
+   *
+   * If omitted, the badge falls back to the legacy heuristic
+   * (`deps.length > 0`) which over-reports blocked status. New call sites
+   * should always pass this prop explicitly.
+   */
+  isBlocked?: boolean;
   /** Callback when clicking on a dependency to navigate */
   onNavigate?: (beadId: string) => void;
 }
@@ -20,11 +30,13 @@ export interface DependencyBadgeProps {
  * Red badge if this task is blocked (has unresolved deps)
  * Orange badge if this task blocks others
  */
-export function DependencyBadge({ deps, blockers, onNavigate }: DependencyBadgeProps) {
+export function DependencyBadge({ deps, blockers, isBlocked: isBlockedProp, onNavigate }: DependencyBadgeProps) {
   // Handle null values from data (default params only work for undefined)
   const safeDeps = deps ?? [];
   const safeBlockers = blockers ?? [];
-  const isBlocked = safeDeps.length > 0;
+  // Parent decides blocked state when isBlocked prop is provided.
+  // Fallback to legacy heuristic only when the prop is omitted (backwards-compat).
+  const isBlocked = isBlockedProp ?? safeDeps.length > 0;
   const isBlocking = safeBlockers.length > 0;
 
   if (!isBlocked && !isBlocking) {

--- a/src/components/epic-card.tsx
+++ b/src/components/epic-card.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useTheme } from "@/hooks/use-theme";
 import * as api from "@/lib/api";
-import { formatBeadId, truncate } from "@/lib/bead-utils";
+import { formatBeadId, isBlocked, truncate } from "@/lib/bead-utils";
 import { closeBead } from "@/lib/cli";
 import { computeEpicProgress } from "@/lib/epic-parser";
 import { cn, isDoltProject } from "@/lib/utils";
@@ -377,7 +377,12 @@ export function EpicCard({
             </span>
           </div>
           <div className="flex items-center gap-1.5">
-            <DependencyBadge deps={epic.deps} blockers={epic.blockers} onNavigate={onNavigateToDependency} />
+            <DependencyBadge
+              deps={epic.deps}
+              blockers={epic.blockers}
+              isBlocked={isBlocked(epic, allBeads)}
+              onNavigate={onNavigateToDependency}
+            />
             <Badge variant="outline" className="text-[10px] px-2 py-0.5 border-epic/30 text-epic bg-epic/20 font-semibold">EPIC</Badge>
           </div>
         </div>

--- a/src/components/kanban-column.tsx
+++ b/src/components/kanban-column.tsx
@@ -164,6 +164,7 @@ export function KanbanColumn({
               <BeadCard
                 key={bead.id}
                 bead={bead}
+                allBeads={allBeads}
                 ticketNumber={ticketNumbers?.get(bead.id)}
                 isSelected={selectedBeadId === bead.id}
                 onSelect={onSelectBead}

--- a/src/lib/__tests__/bead-utils.test.ts
+++ b/src/lib/__tests__/bead-utils.test.ts
@@ -93,16 +93,43 @@ describe('truncate', () => {
 });
 
 describe('isBlocked', () => {
-  it('returns false for closed tasks', () => {
-    expect(isBlocked({ status: 'closed', deps: ['dep1'] })).toBe(false);
+  it('returns false for closed tasks even with open deps', () => {
+    const allBeads = [{ id: 'dep1', status: 'open' }];
+    expect(isBlocked({ status: 'closed', deps: ['dep1'] }, allBeads)).toBe(false);
   });
 
-  it('returns true for open tasks with deps', () => {
-    expect(isBlocked({ status: 'open', deps: ['dep1'] })).toBe(true);
+  it('returns false for open tasks whose only dep is closed', () => {
+    const allBeads = [{ id: 'dep1', status: 'closed' }];
+    expect(isBlocked({ status: 'open', deps: ['dep1'] }, allBeads)).toBe(false);
   });
 
-  it('returns false for tasks without deps', () => {
-    expect(isBlocked({ status: 'open', deps: [] })).toBe(false);
-    expect(isBlocked({ status: 'open' })).toBe(false);
+  it('returns true when at least one dep is not closed (one open, one closed)', () => {
+    const allBeads = [
+      { id: 'dep1', status: 'closed' },
+      { id: 'dep2', status: 'open' },
+    ];
+    expect(isBlocked({ status: 'open', deps: ['dep1', 'dep2'] }, allBeads)).toBe(true);
+  });
+
+  it('returns true when dep is in_progress', () => {
+    const allBeads = [{ id: 'dep1', status: 'in_progress' }];
+    expect(isBlocked({ status: 'open', deps: ['dep1'] }, allBeads)).toBe(true);
+  });
+
+  it('returns false when dep references a missing bead', () => {
+    const allBeads = [{ id: 'other', status: 'open' }];
+    expect(isBlocked({ status: 'open', deps: ['ghost'] }, allBeads)).toBe(false);
+  });
+
+  it('returns false for open task with empty deps array', () => {
+    expect(isBlocked({ status: 'open', deps: [] }, [])).toBe(false);
+  });
+
+  it('returns false for open task without deps property', () => {
+    expect(isBlocked({ status: 'open' }, [])).toBe(false);
+  });
+
+  it('returns false when deps is null', () => {
+    expect(isBlocked({ status: 'open', deps: null }, [])).toBe(false);
   });
 });

--- a/src/lib/bead-utils.ts
+++ b/src/lib/bead-utils.ts
@@ -97,9 +97,28 @@ export function truncate(text: string, maxLength: number): string {
 
 /**
  * Detect if bead is blocked by checking for unresolved dependencies.
- * Closed tasks are never blocked.
+ *
+ * A bead is blocked when at least one of its dependencies (resolved
+ * via {@link allBeads}) has a status other than `closed`. Closed beads
+ * are never considered blocked. Dependencies that cannot be found in
+ * {@link allBeads} (e.g. references to deleted beads) do NOT block —
+ * this matches the behaviour of `bd ready` and `getBlockedTasks` in
+ * `epic-parser.ts`.
+ *
+ * @param bead - The bead to evaluate (only `status` and `deps` are used).
+ * @param allBeads - All beads available for dep resolution. Pass the
+ *   full board state — `deps` lookup is O(deps.length) over a Map.
  */
-export function isBlocked(bead: { status: string; deps?: string[] }): boolean {
+export function isBlocked(
+  bead: { status: string; deps?: string[] | null },
+  allBeads: ReadonlyArray<{ id: string; status: string }>,
+): boolean {
   if (bead.status === "closed") return false;
-  return (bead.deps ?? []).length > 0;
+  const deps = bead.deps ?? [];
+  if (deps.length === 0) return false;
+  const statusById = new Map(allBeads.map((b) => [b.id, b.status]));
+  return deps.some((depId) => {
+    const status = statusById.get(depId);
+    return status !== undefined && status !== "closed";
+  });
 }


### PR DESCRIPTION
## Summary
- BLOCKED badge hides when all deps are closed, matching `bd ready` semantics
- `isBlocked(bead, allBeads)` resolves deps via Map and checks `status !== closed`
- `DependencyBadge` accepts explicit `isBlocked` prop — parent decides

## Why
UI showed BLOCKED on epics whose deps were already closed (e.g. BD-pwe, BD-5jz),
while CLI correctly reported them OPEN. The bug was in two places using
`deps.length > 0` as the blocked heuristic without checking actual dep statuses.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `vitest bead-utils.test.ts` — 22/22 (incl. regression "open + closed dep → false")
- [ ] Manual: load project where all epic deps are closed → no BLOCKED badge

Closes beads-web-4sw

🤖 Generated with [Claude Code](https://claude.com/claude-code)