### PR TITLE
feat(api): POST /api/projects/:id/touch endpoint

### DIFF
--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -434,6 +434,20 @@ impl Database {
         Ok(())
     }
 
+    /// Updates `last_opened` to current time without touching any other field. Returns ProjectNotFound when no row matches.
+    pub fn touch_project(&self, id: &str) -> Result<(), DbError> {
+        let conn = self.conn.lock().unwrap();
+        let now = Utc::now().to_rfc3339();
+        let rows = conn.execute(
+            "UPDATE projects SET last_opened = ?1 WHERE id = ?2",
+            params![now, id],
+        )?;
+        if rows == 0 {
+            return Err(DbError::ProjectNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     /// Looks up a project by its `path` column.
     ///
     /// Returns `Ok(None)` when no project matches (not an error — the caller
@@ -803,6 +817,49 @@ mod tests {
         let active = db.get_projects_filtered(false).unwrap();
         assert_eq!(active.len(), 1);
         assert!(active[0].archived_at.is_none());
+    }
+
+    #[test]
+    fn test_touch_project_updates_last_opened() {
+        let db = Database::new_in_memory().unwrap();
+        let project = db
+            .create_project(CreateProjectInput {
+                name: "Touchable".to_string(),
+                path: "/touch/me".to_string(),
+                local_path: None,
+            })
+            .unwrap();
+
+        let original = project.last_opened.clone();
+        // Sleep so the RFC3339 timestamp is guaranteed to differ on fast machines
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        db.touch_project(&project.id).unwrap();
+
+        let projects = db.get_projects_filtered(false).unwrap();
+        let touched = projects
+            .iter()
+            .find(|p| p.id == project.id)
+            .expect("project should still exist after touch");
+
+        // last_opened bumped (RFC3339 string compare is monotonic for same TZ)
+        assert_ne!(touched.last_opened, original);
+        assert!(
+            touched.last_opened.as_str() > original.as_str(),
+            "expected new last_opened ({}) > original ({})",
+            touched.last_opened,
+            original
+        );
+        // Other fields untouched
+        assert_eq!(touched.name, project.name);
+        assert_eq!(touched.path, project.path);
+    }
+
+    #[test]
+    fn test_touch_project_not_found() {
+        let db = Database::new_in_memory().unwrap();
+        let result = db.touch_project("does-not-exist-uuid");
+        assert!(matches!(result, Err(DbError::ProjectNotFound(_))));
     }
 
     #[test]

--- a/server/src/routes/projects.rs
+++ b/server/src/routes/projects.rs
@@ -177,6 +177,15 @@ pub async fn unarchive_project(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// POST /api/projects/:id/touch — bump last_opened to now without touching other fields
+pub async fn touch_project(
+    State(db): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    db.touch_project(&id).map_err(db_error_response)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 // ===== Tag Routes =====
 
 /// GET /api/tags - List all tags
@@ -239,6 +248,7 @@ pub fn project_routes() -> axum::Router<AppState> {
         )
         .route("/projects/:id/archive", patch(archive_project))
         .route("/projects/:id/unarchive", patch(unarchive_project))
+        .route("/projects/:id/touch", post(touch_project))
         // Tag routes
         .route("/tags", get(list_tags).post(create_tag))
         .route("/tags/:id", delete(delete_tag))


### PR DESCRIPTION
## Summary
- New endpoint that bumps `last_opened` to now without touching other fields
- Body-less POST, returns 204 on success / 404 on unknown id
- Used by upcoming frontend bump on kanban page load

## Why
The dashboard SQL already orders by `last_opened DESC` but the column is
only written on create/update. Opening a kanban page didn't bump it, so
the order reflected last metadata edit, not last open. This endpoint is
the backend half of fixing that.

## Test plan
- [x] `cargo build` — pass
- [x] `cargo test` — 155 tests pass (2 new: `test_touch_project_updates_last_opened`, `test_touch_project_not_found`)
- [ ] Frontend wiring lands in beads-web-r59.2 (next PR)

Refs beads-web-r59 (epic), beads-web-r59.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)