### PR TITLE
feat(ui): bump last_opened on kanban page load

### DIFF
--- a/src/hooks/use-project.ts
+++ b/src/hooks/use-project.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
+import * as api from "@/lib/api";
 import { getProjectWithTags, type Project, type Tag } from "@/lib/db";
 
 export interface ProjectWithTags extends Project {
@@ -25,6 +26,7 @@ export function useProject(projectId: string | null): UseProjectResult {
   const [project, setProject] = useState<ProjectWithTags | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const touchedProjectIdRef = useRef<string | null>(null);
 
   const fetchProject = useCallback(async () => {
     if (!projectId) {
@@ -39,6 +41,12 @@ export function useProject(projectId: string | null): UseProjectResult {
       setError(null);
       const data = await getProjectWithTags(projectId);
       setProject(data);
+      if (touchedProjectIdRef.current !== projectId) {
+        touchedProjectIdRef.current = projectId;
+        api.projects.touch(projectId).catch((err) => {
+          console.warn(`Failed to touch project ${projectId}:`, err);
+        });
+      }
     } catch (err) {
       setError(
         err instanceof Error ? err : new Error("Failed to fetch project")

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -108,6 +108,8 @@ export const projects = {
 
   unarchive: (id: string) => fetchApi<void>(`/api/projects/${id}/unarchive`, { method: 'PATCH' }),
 
+  touch: (id: string) => fetchApi<void>(`/api/projects/${id}/touch`, { method: 'POST' }),
+
   listAll: () => fetchApi<Project[]>('/api/projects?include_archived=true'),
 };
 


### PR DESCRIPTION
## Summary
- `api.projects.touch(id)` — POST to `/api/projects/:id/touch`
- `useProject` hook calls touch fire-and-forget after first successful
  fetch per `projectId`; `useRef` guard prevents repeats on refetch/SSE
- Errors logged via `console.warn` — UI unaffected

## Why
Completes the epic: opening any kanban page now bumps the project to
the top of the dashboard on next refresh. Combined with #18 (backend
endpoint), the dashboard ordering finally reflects "most recently
worked on" rather than "most recently edited metadata".

## Test plan
- [x] `npm run lint` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npx vitest run` — no new failures (6 pre-existing failures on main unrelated)
- [ ] Manual: open A → return → open B → return → B is first, A second

Closes beads-web-r59.2
Closes beads-web-r59 (epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)