### PR TITLE
refactor: memory panel uses bd CLI instead of JSONL store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beads-web",
-  "version": "0.5.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beads-web",
-      "version": "0.5.0",
+      "version": "0.11.0",
       "dependencies": {
         "@base-ui/react": "^1.1.0",
         "@dnd-kit/core": "^6.3.1",
@@ -46,6 +46,7 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20.0.0",
@@ -83,6 +84,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1425,6 +1427,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1446,6 +1449,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1455,12 +1459,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1662,6 +1668,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1675,6 +1682,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1684,6 +1692,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -4056,7 +4065,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4077,7 +4085,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4159,8 +4166,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4385,7 +4391,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -5232,12 +5238,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5251,6 +5259,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5602,6 +5611,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5625,6 +5635,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5766,6 +5777,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5881,6 +5893,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5905,6 +5918,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6029,6 +6043,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6166,6 +6181,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -6539,12 +6555,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6565,8 +6583,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -7392,6 +7409,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7408,6 +7426,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7434,6 +7453,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7462,6 +7482,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7594,6 +7615,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7608,6 +7630,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7780,6 +7803,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -7964,6 +7988,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8311,6 +8336,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8363,6 +8389,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -8423,6 +8450,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8478,6 +8506,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8526,6 +8555,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8803,6 +8833,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -8988,6 +9019,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -9000,6 +9032,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -9090,7 +9123,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9289,6 +9321,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -9755,6 +9788,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -9858,6 +9892,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -9995,6 +10030,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10013,6 +10049,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10310,6 +10347,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -10346,6 +10384,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10358,6 +10397,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10367,6 +10407,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10433,6 +10474,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10461,6 +10503,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -10478,6 +10521,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10503,6 +10547,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10545,6 +10590,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10570,6 +10616,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -10583,6 +10630,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/potpack": {
@@ -10607,7 +10655,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10623,7 +10670,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10636,8 +10682,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
@@ -10684,6 +10729,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11066,6 +11112,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -11075,6 +11122,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11258,6 +11306,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -11298,6 +11347,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -11392,6 +11442,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12089,6 +12140,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -12124,6 +12176,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12168,6 +12221,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -12221,6 +12275,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -12230,6 +12285,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -12304,6 +12360,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -12320,6 +12377,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -12337,6 +12395,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12379,6 +12438,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -12490,6 +12550,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -12935,6 +12996,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utility-types": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20.0.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,3 +29,4 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 
 [dev-dependencies]
 tempfile = "3"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/server/src/dolt.rs
+++ b/server/src/dolt.rs
@@ -38,6 +38,12 @@ pub struct DoltManager {
     available: AtomicBool,
 }
 
+impl Default for DoltManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DoltManager {
     /// Creates a new DoltManager with a connection pool to Dolt.
     pub fn new() -> Self {
@@ -104,6 +110,7 @@ impl DoltManager {
     }
 
     /// Creates a new bead in a Dolt database and commits the change.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_bead(
         &self,
         db_name: &str,
@@ -121,13 +128,11 @@ impl DoltManager {
 
         // First, query the table schema to find all NOT NULL columns without defaults
         // so we can provide empty values for them
-        let schema_query = format!(
-            "SELECT COLUMN_NAME FROM information_schema.COLUMNS \
+        let schema_query = "SELECT COLUMN_NAME FROM information_schema.COLUMNS \
              WHERE TABLE_SCHEMA = :db AND TABLE_NAME = 'issues' \
              AND IS_NULLABLE = 'NO' AND COLUMN_DEFAULT IS NULL \
              AND COLUMN_NAME NOT IN ('id', 'title', 'description', 'status', 'priority', \
-             'issue_type', 'owner', 'created_at', 'updated_at')"
-        );
+             'issue_type', 'owner', 'created_at', 'updated_at')".to_string();
         let extra_cols: Vec<String> = conn.exec_map(
             &schema_query,
             mysql_async::params! { "db" => db_name },

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,0 +1,14 @@
+// Library entry point — exposes modules for integration tests.
+//
+// Allow pre-existing clippy violations in modules that were written for
+// binary-only use and are not part of this refactor.
+#![allow(clippy::new_without_default)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::useless_format)]
+#![allow(clippy::manual_map)]
+#![allow(clippy::ptr_arg)]
+#![allow(private_interfaces)]
+
+pub mod db;
+pub mod dolt;
+pub mod routes;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,14 +1,4 @@
 // Library entry point — exposes modules for integration tests.
-//
-// Allow pre-existing clippy violations in modules that were written for
-// binary-only use and are not part of this refactor.
-#![allow(clippy::new_without_default)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::useless_format)]
-#![allow(clippy::manual_map)]
-#![allow(clippy::ptr_arg)]
-#![allow(private_interfaces)]
-
 pub mod db;
 pub mod dolt;
 pub mod routes;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -187,7 +187,6 @@ async fn main() {
                 .put(routes::memory::update_memory)
                 .delete(routes::memory::delete_memory),
         )
-        .route("/api/memory/stats", get(routes::memory::memory_stats))
         .route("/api/watch/beads", get(routes::watch_beads))
         .route("/api/version/check", get(routes::version::version_check))
         .route("/api/update", post(routes::version::perform_update))

--- a/server/src/routes/dolt.rs
+++ b/server/src/routes/dolt.rs
@@ -2,7 +2,7 @@
 
 use axum::{extract::Extension, response::IntoResponse, Json};
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::db::Database;
@@ -307,10 +307,8 @@ fn parse_data_dir_from_cmdline(cmdline: &str) -> Option<PathBuf> {
     for (i, part) in parts.iter().enumerate() {
         let data_dir = if (*part == "--data-dir") && i + 1 < parts.len() {
             Some(parts[i + 1])
-        } else if let Some(val) = part.strip_prefix("--data-dir=") {
-            Some(val)
         } else {
-            None
+            part.strip_prefix("--data-dir=")
         };
 
         if let Some(dir) = data_dir {
@@ -328,7 +326,7 @@ fn parse_data_dir_from_cmdline(cmdline: &str) -> Option<PathBuf> {
 }
 
 /// Strips `.beads/dolt/` or `.beads/dolt` suffix from a path to get the project root.
-fn strip_beads_dolt_suffix(path: &PathBuf) -> Option<PathBuf> {
+fn strip_beads_dolt_suffix(path: &Path) -> Option<PathBuf> {
     let path_str = path.to_string_lossy();
     // Normalize separators for matching
     let normalized = path_str.replace('\\', "/");

--- a/server/src/routes/memory.rs
+++ b/server/src/routes/memory.rs
@@ -1,7 +1,7 @@
-//! Memory API route handlers.
+//! Memory API route handlers backed by the `bd` CLI.
 //!
-//! Provides endpoints for reading, editing, and deleting knowledge base entries
-//! from `.beads/memory/knowledge.jsonl` files.
+//! Delegates all storage to `bd remember` / `bd forget` / `bd memories`,
+//! which is the canonical memory store for beads projects.
 
 use axum::{
     extract::Query,
@@ -10,201 +10,85 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-use std::io::Write;
 use std::path::{Path, PathBuf};
+use tokio::process::Command;
 
-use super::validate_path_security;
+use super::{find_bd, validate_path_security};
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/// A single memory/knowledge entry from the JSONL file.
+/// A single memory entry as stored by `bd remember`.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MemoryEntry {
     pub key: String,
-    #[serde(rename = "type")]
-    pub entry_type: String,
     pub content: String,
-    pub source: String,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    pub ts: i64,
-    #[serde(default)]
-    pub bead: String,
 }
 
-/// Aggregated statistics about memory entries.
-#[derive(Debug, Serialize)]
-pub struct MemoryStats {
-    pub total: usize,
-    pub learned: usize,
-    pub investigation: usize,
-    pub archived: usize,
-}
-
-/// Response for the list memory endpoint.
-#[derive(Debug, Serialize)]
-pub struct MemoryListResponse {
-    pub entries: Vec<MemoryEntry>,
-    pub stats: MemoryStats,
-}
-
-/// Query parameters for GET endpoints.
+/// Query parameters for GET /api/memory.
 #[derive(Debug, Deserialize)]
 pub struct MemoryParams {
     pub path: String,
 }
 
-/// Request body for the update memory endpoint.
+/// Request body for PUT /api/memory.
 #[derive(Debug, Deserialize)]
 pub struct UpdateMemoryRequest {
     pub path: String,
+    /// Key for the entry. Empty string means bd auto-generates one.
     pub key: String,
-    pub content: Option<String>,
-    pub tags: Option<Vec<String>>,
+    pub content: String,
 }
 
-/// Request body for the delete memory endpoint.
+/// Request body for DELETE /api/memory.
 #[derive(Debug, Deserialize)]
 pub struct DeleteMemoryRequest {
     pub path: String,
     pub key: String,
-    #[serde(default)]
-    pub archive: bool,
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Internal helper
 // ---------------------------------------------------------------------------
 
-/// Build the path to the active knowledge file.
-fn knowledge_path(project_path: &Path) -> PathBuf {
-    project_path
-        .join(".beads")
-        .join("memory")
-        .join("knowledge.jsonl")
-}
-
-/// Build the path to the archive knowledge file.
-fn archive_path(project_path: &Path) -> PathBuf {
-    project_path
-        .join(".beads")
-        .join("memory")
-        .join("knowledge.archive.jsonl")
-}
-
-/// Parse a JSONL file into a list of `MemoryEntry` values.
+/// Spawn `bd -C <project_path> <args...>` and return stdout on success.
 ///
-/// Missing files are treated as empty. Malformed lines are skipped with a
-/// warning logged via `tracing`.
-fn read_entries(path: &PathBuf) -> Result<Vec<MemoryEntry>, String> {
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
+/// On non-zero exit returns `(400, stderr)`.
+/// On spawn failure or missing binary returns `(500, message)`.
+async fn run_bd(project_path: &Path, args: &[&str]) -> Result<String, (StatusCode, String)> {
+    let bd = find_bd().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "bd CLI not found; install beads and ensure bd is in PATH".to_string(),
+        )
+    })?;
 
-    let contents = std::fs::read_to_string(path)
-        .map_err(|e| format!("Failed to read file: {}", e))?;
+    let output = Command::new(bd)
+        .arg("-C")
+        .arg(project_path)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to spawn bd: {e}"),
+            )
+        })?;
 
-    let mut entries = Vec::new();
-    for (line_num, line) in contents.lines().enumerate() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        match serde_json::from_str::<MemoryEntry>(line) {
-            Ok(entry) => entries.push(entry),
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to parse memory entry at line {}: {} - {}",
-                    line_num + 1,
-                    e,
-                    line
-                );
-            }
-        }
-    }
-
-    Ok(entries)
-}
-
-/// Write a list of entries back to a JSONL file (overwrite).
-fn write_entries(path: &PathBuf, entries: &[MemoryEntry]) -> Result<(), String> {
-    let file = std::fs::File::create(path)
-        .map_err(|e| format!("Failed to open file for writing: {}", e))?;
-
-    let mut writer = std::io::BufWriter::new(file);
-    for entry in entries {
-        let json_line = serde_json::to_string(entry)
-            .map_err(|e| format!("Failed to serialize entry: {}", e))?;
-        writeln!(writer, "{}", json_line)
-            .map_err(|e| format!("Failed to write to file: {}", e))?;
-    }
-    writer
-        .flush()
-        .map_err(|e| format!("Failed to flush file: {}", e))?;
-
-    Ok(())
-}
-
-/// Append a single entry to a JSONL file (creating the file if needed).
-fn append_entry(path: &PathBuf, entry: &MemoryEntry) -> Result<(), String> {
-    // Ensure parent directory exists
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create directory: {}", e))?;
-    }
-
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|e| format!("Failed to open archive file: {}", e))?;
-
-    let mut writer = std::io::BufWriter::new(file);
-    let json_line = serde_json::to_string(entry)
-        .map_err(|e| format!("Failed to serialize entry: {}", e))?;
-    writeln!(writer, "{}", json_line)
-        .map_err(|e| format!("Failed to write to archive: {}", e))?;
-    writer
-        .flush()
-        .map_err(|e| format!("Failed to flush archive: {}", e))?;
-
-    Ok(())
-}
-
-/// Count the number of entries in a JSONL file (for archive stats).
-fn count_entries(path: &PathBuf) -> usize {
-    if !path.exists() {
-        return 0;
-    }
-
-    match std::fs::read_to_string(path) {
-        Ok(contents) => contents
-            .lines()
-            .filter(|line| {
-                let trimmed = line.trim();
-                !trimmed.is_empty()
-            })
-            .count(),
-        Err(_) => 0,
-    }
-}
-
-/// Compute stats from a list of entries plus an archived count.
-fn compute_stats(entries: &[MemoryEntry], archived: usize) -> MemoryStats {
-    let learned = entries.iter().filter(|e| e.entry_type == "learned").count();
-    let investigation = entries
-        .iter()
-        .filter(|e| e.entry_type == "investigation")
-        .count();
-
-    MemoryStats {
-        total: entries.len(),
-        learned,
-        investigation,
-        archived,
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        let msg = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err((
+            StatusCode::BAD_REQUEST,
+            if msg.is_empty() {
+                format!("bd exited with status {}", output.status)
+            } else {
+                msg
+            },
+        ))
     }
 }
 
@@ -214,436 +98,111 @@ fn compute_stats(entries: &[MemoryEntry], archived: usize) -> MemoryStats {
 
 /// GET /api/memory?path={project_path}
 ///
-/// Reads all entries from the active knowledge file and returns them along
-/// with aggregate statistics. Entries are sorted by `ts` descending (newest
-/// first).
+/// Lists all memories stored by `bd remember` in the given project.
 pub async fn list_memory(Query(params): Query<MemoryParams>) -> impl IntoResponse {
     let project_path = PathBuf::from(&params.path);
 
-    // Security: Validate path is within allowed directories
     if let Err(e) = validate_path_security(&project_path) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({ "error": e })),
-        );
+        )
+            .into_response();
     }
 
-    let kpath = knowledge_path(&project_path);
-    let apath = archive_path(&project_path);
-
-    let mut entries = match read_entries(&kpath) {
-        Ok(e) => e,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            );
+    let stdout = match run_bd(&project_path, &["memories", "--json"]).await {
+        Ok(s) => s,
+        Err((code, msg)) => {
+            return (code, Json(serde_json::json!({ "error": msg }))).into_response();
         }
     };
 
-    // Sort by ts descending (newest first)
-    entries.sort_by(|a, b| b.ts.cmp(&a.ts));
+    // `bd memories --json` returns a flat object: {"schema_version":1,"key":"content",...}
+    let map: serde_json::Map<String, serde_json::Value> =
+        match serde_json::from_str(stdout.trim()) {
+            Ok(m) => m,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": format!("Failed to parse bd output: {e}") })),
+                )
+                    .into_response();
+            }
+        };
 
-    let archived = count_entries(&apath);
-    let stats = compute_stats(&entries, archived);
+    let entries: Vec<MemoryEntry> = map
+        .into_iter()
+        .filter_map(|(k, v)| {
+            if k == "schema_version" {
+                return None;
+            }
+            v.as_str().map(|s| MemoryEntry {
+                key: k,
+                content: s.to_string(),
+            })
+        })
+        .collect();
 
-    (
-        StatusCode::OK,
-        Json(serde_json::json!(MemoryListResponse { entries, stats })),
-    )
-}
-
-/// GET /api/memory/stats?path={project_path}
-///
-/// Lightweight endpoint returning only aggregate statistics (no entry content).
-pub async fn memory_stats(Query(params): Query<MemoryParams>) -> impl IntoResponse {
-    let project_path = PathBuf::from(&params.path);
-
-    // Security: Validate path is within allowed directories
-    if let Err(e) = validate_path_security(&project_path) {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({ "error": e })),
-        );
-    }
-
-    let kpath = knowledge_path(&project_path);
-    let apath = archive_path(&project_path);
-
-    let entries = match read_entries(&kpath) {
-        Ok(e) => e,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            );
-        }
-    };
-
-    let archived = count_entries(&apath);
-    let stats = compute_stats(&entries, archived);
-
-    (StatusCode::OK, Json(serde_json::json!(stats)))
+    (StatusCode::OK, Json(entries)).into_response()
 }
 
 /// PUT /api/memory
 ///
-/// Edit an existing entry by key. Updates `content` and/or `tags` fields.
-/// At least one of `content` or `tags` must be provided.
-/// The `ts` field is NOT updated (it represents original creation time).
+/// Upsert a memory entry via `bd remember`. If `key` is empty, bd
+/// auto-generates one (returned key will be empty in the response; the
+/// frontend should re-fetch to get the new key).
 pub async fn update_memory(Json(payload): Json<UpdateMemoryRequest>) -> impl IntoResponse {
-    // Validate that at least one field is provided
-    if payload.content.is_none() && payload.tags.is_none() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({
-                "error": "At least one of 'content' or 'tags' must be provided"
-            })),
-        );
-    }
-
     let project_path = PathBuf::from(&payload.path);
 
-    // Security: Validate path is within allowed directories
     if let Err(e) = validate_path_security(&project_path) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({ "error": e })),
-        );
+        )
+            .into_response();
     }
 
-    let kpath = knowledge_path(&project_path);
-
-    let mut entries = match read_entries(&kpath) {
-        Ok(e) => e,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            );
-        }
+    let result = if payload.key.is_empty() {
+        run_bd(&project_path, &["remember", &payload.content]).await
+    } else {
+        run_bd(
+            &project_path,
+            &["remember", &payload.content, "--key", &payload.key],
+        )
+        .await
     };
 
-    // Find the entry with the matching key
-    let entry_pos = entries.iter().position(|e| e.key == payload.key);
-
-    let idx = match entry_pos {
-        Some(i) => i,
-        None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({
-                    "error": format!("Entry with key '{}' not found", payload.key)
-                })),
-            );
-        }
-    };
-
-    // Update fields
-    if let Some(content) = payload.content {
-        entries[idx].content = content;
-    }
-    if let Some(tags) = payload.tags {
-        entries[idx].tags = tags;
+    if let Err((code, msg)) = result {
+        return (code, Json(serde_json::json!({ "error": msg }))).into_response();
     }
 
-    // Write back
-    if let Err(e) = write_entries(&kpath, &entries) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": e })),
-        );
-    }
-
-    let updated_entry = entries[idx].clone();
     (
         StatusCode::OK,
-        Json(serde_json::json!({
-            "success": true,
-            "entry": updated_entry
-        })),
+        Json(MemoryEntry {
+            key: payload.key,
+            content: payload.content,
+        }),
     )
+        .into_response()
 }
 
 /// DELETE /api/memory
 ///
-/// Remove or archive an entry by key.
-///
-/// - `archive: true`  — Move entry to `knowledge.archive.jsonl`, then remove
-///   from `knowledge.jsonl`.
-/// - `archive: false` — Permanently delete from `knowledge.jsonl`.
+/// Permanently delete a memory entry via `bd forget`.
 pub async fn delete_memory(Json(payload): Json<DeleteMemoryRequest>) -> impl IntoResponse {
     let project_path = PathBuf::from(&payload.path);
 
-    // Security: Validate path is within allowed directories
     if let Err(e) = validate_path_security(&project_path) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({ "error": e })),
-        );
+        )
+            .into_response();
     }
 
-    let kpath = knowledge_path(&project_path);
-
-    let mut entries = match read_entries(&kpath) {
-        Ok(e) => e,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            );
-        }
-    };
-
-    // Find the entry with the matching key
-    let entry_pos = entries.iter().position(|e| e.key == payload.key);
-
-    let idx = match entry_pos {
-        Some(i) => i,
-        None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Json(serde_json::json!({
-                    "error": format!("Entry with key '{}' not found", payload.key)
-                })),
-            );
-        }
-    };
-
-    // Remove the entry
-    let removed_entry = entries.remove(idx);
-
-    // If archiving, append to archive file
-    if payload.archive {
-        let apath = archive_path(&project_path);
-        if let Err(e) = append_entry(&apath, &removed_entry) {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e })),
-            );
-        }
+    if let Err((code, msg)) = run_bd(&project_path, &["forget", &payload.key]).await {
+        return (code, Json(serde_json::json!({ "error": msg }))).into_response();
     }
 
-    // Write back the remaining entries
-    if let Err(e) = write_entries(&kpath, &entries) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": e })),
-        );
-    }
-
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({
-            "success": true,
-            "archived": payload.archive
-        })),
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_memory_entry() {
-        let json = r#"{"key":"test-key","type":"learned","content":"Some content","source":"orchestrator","tags":["tag1","tag2"],"ts":1769505562,"bead":"project-id.3"}"#;
-        let entry: MemoryEntry = serde_json::from_str(json).unwrap();
-        assert_eq!(entry.key, "test-key");
-        assert_eq!(entry.entry_type, "learned");
-        assert_eq!(entry.content, "Some content");
-        assert_eq!(entry.source, "orchestrator");
-        assert_eq!(entry.tags, vec!["tag1", "tag2"]);
-        assert_eq!(entry.ts, 1769505562);
-        assert_eq!(entry.bead, "project-id.3");
-    }
-
-    #[test]
-    fn test_parse_memory_entry_investigation() {
-        let json = r#"{"key":"inv-key","type":"investigation","content":"Root cause analysis","source":"detective","tags":["investigation"],"ts":1769505000,"bead":"bd-42.1"}"#;
-        let entry: MemoryEntry = serde_json::from_str(json).unwrap();
-        assert_eq!(entry.entry_type, "investigation");
-    }
-
-    #[test]
-    fn test_parse_memory_entry_defaults() {
-        // tags and bead are optional (have defaults)
-        let json = r#"{"key":"min-key","type":"learned","content":"Minimal","source":"src","ts":100}"#;
-        let entry: MemoryEntry = serde_json::from_str(json).unwrap();
-        assert_eq!(entry.tags, Vec::<String>::new());
-        assert_eq!(entry.bead, "");
-    }
-
-    #[test]
-    fn test_serialize_memory_entry() {
-        let entry = MemoryEntry {
-            key: "k".to_string(),
-            entry_type: "learned".to_string(),
-            content: "c".to_string(),
-            source: "s".to_string(),
-            tags: vec!["t".to_string()],
-            ts: 42,
-            bead: "b".to_string(),
-        };
-        let json = serde_json::to_string(&entry).unwrap();
-        // The field should serialize as "type", not "entry_type"
-        assert!(json.contains(r#""type":"learned""#));
-        assert!(!json.contains("entry_type"));
-    }
-
-    #[test]
-    fn test_compute_stats() {
-        let entries = vec![
-            MemoryEntry {
-                key: "a".into(),
-                entry_type: "learned".into(),
-                content: "".into(),
-                source: "".into(),
-                tags: vec![],
-                ts: 1,
-                bead: "".into(),
-            },
-            MemoryEntry {
-                key: "b".into(),
-                entry_type: "learned".into(),
-                content: "".into(),
-                source: "".into(),
-                tags: vec![],
-                ts: 2,
-                bead: "".into(),
-            },
-            MemoryEntry {
-                key: "c".into(),
-                entry_type: "investigation".into(),
-                content: "".into(),
-                source: "".into(),
-                tags: vec![],
-                ts: 3,
-                bead: "".into(),
-            },
-        ];
-
-        let stats = compute_stats(&entries, 5);
-        assert_eq!(stats.total, 3);
-        assert_eq!(stats.learned, 2);
-        assert_eq!(stats.investigation, 1);
-        assert_eq!(stats.archived, 5);
-    }
-
-    #[test]
-    fn test_compute_stats_empty() {
-        let stats = compute_stats(&[], 0);
-        assert_eq!(stats.total, 0);
-        assert_eq!(stats.learned, 0);
-        assert_eq!(stats.investigation, 0);
-        assert_eq!(stats.archived, 0);
-    }
-
-    #[test]
-    fn test_read_entries_missing_file() {
-        let path = PathBuf::from("/nonexistent/path/knowledge.jsonl");
-        let result = read_entries(&path);
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
-    }
-
-    #[test]
-    fn test_count_entries_missing_file() {
-        let path = PathBuf::from("/nonexistent/path/knowledge.jsonl");
-        assert_eq!(count_entries(&path), 0);
-    }
-
-    #[test]
-    fn test_write_and_read_entries() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.jsonl");
-
-        let entries = vec![
-            MemoryEntry {
-                key: "k1".into(),
-                entry_type: "learned".into(),
-                content: "content1".into(),
-                source: "src".into(),
-                tags: vec!["a".into()],
-                ts: 100,
-                bead: "b1".into(),
-            },
-            MemoryEntry {
-                key: "k2".into(),
-                entry_type: "investigation".into(),
-                content: "content2".into(),
-                source: "src".into(),
-                tags: vec![],
-                ts: 200,
-                bead: "b2".into(),
-            },
-        ];
-
-        write_entries(&path, &entries).unwrap();
-        let read_back = read_entries(&path).unwrap();
-
-        assert_eq!(read_back.len(), 2);
-        assert_eq!(read_back[0].key, "k1");
-        assert_eq!(read_back[0].entry_type, "learned");
-        assert_eq!(read_back[1].key, "k2");
-        assert_eq!(read_back[1].entry_type, "investigation");
-    }
-
-    #[test]
-    fn test_append_entry() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("archive.jsonl");
-
-        let entry1 = MemoryEntry {
-            key: "k1".into(),
-            entry_type: "learned".into(),
-            content: "c1".into(),
-            source: "s".into(),
-            tags: vec![],
-            ts: 1,
-            bead: "".into(),
-        };
-
-        let entry2 = MemoryEntry {
-            key: "k2".into(),
-            entry_type: "investigation".into(),
-            content: "c2".into(),
-            source: "s".into(),
-            tags: vec![],
-            ts: 2,
-            bead: "".into(),
-        };
-
-        append_entry(&path, &entry1).unwrap();
-        append_entry(&path, &entry2).unwrap();
-
-        let entries = read_entries(&path).unwrap();
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].key, "k1");
-        assert_eq!(entries[1].key, "k2");
-    }
-
-    #[test]
-    fn test_knowledge_path() {
-        let project = PathBuf::from("/home/user/project");
-        let kp = knowledge_path(&project);
-        assert_eq!(
-            kp,
-            PathBuf::from("/home/user/project/.beads/memory/knowledge.jsonl")
-        );
-    }
-
-    #[test]
-    fn test_archive_path() {
-        let project = PathBuf::from("/home/user/project");
-        let ap = archive_path(&project);
-        assert_eq!(
-            ap,
-            PathBuf::from("/home/user/project/.beads/memory/knowledge.archive.jsonl")
-        );
-    }
+    (StatusCode::OK, Json(serde_json::json!({ "success": true }))).into_response()
 }

--- a/server/src/routes/memory.rs
+++ b/server/src/routes/memory.rs
@@ -162,24 +162,37 @@ pub async fn update_memory(Json(payload): Json<UpdateMemoryRequest>) -> impl Int
             .into_response();
     }
 
-    let result = if payload.key.is_empty() {
-        run_bd(&project_path, &["remember", &payload.content]).await
+    let stdout = if payload.key.is_empty() {
+        run_bd(&project_path, &["remember", &payload.content, "--json"]).await
     } else {
         run_bd(
             &project_path,
-            &["remember", &payload.content, "--key", &payload.key],
+            &["remember", &payload.content, "--key", &payload.key, "--json"],
         )
         .await
     };
 
-    if let Err((code, msg)) = result {
-        return (code, Json(serde_json::json!({ "error": msg }))).into_response();
-    }
+    let stdout = match stdout {
+        Ok(s) => s,
+        Err((code, msg)) => {
+            return (code, Json(serde_json::json!({ "error": msg }))).into_response();
+        }
+    };
+
+    // Parse the --json response to extract the bd-assigned key.
+    // Response shape: {"action":"remembered","key":"<key>","schema_version":1,"value":"<content>"}
+    let returned_key = serde_json::from_str::<serde_json::Value>(stdout.trim())
+        .ok()
+        .and_then(|v| v.get("key").and_then(|k| k.as_str()).map(|s| s.to_string()))
+        .unwrap_or_else(|| {
+            tracing::warn!("bd --json response missing 'key' field; falling back to payload key");
+            payload.key.clone()
+        });
 
     (
         StatusCode::OK,
         Json(MemoryEntry {
-            key: payload.key,
+            key: returned_key,
             content: payload.content,
         }),
     )

--- a/server/src/routes/version.rs
+++ b/server/src/routes/version.rs
@@ -21,7 +21,7 @@ const CACHE_TTL_SECS: u64 = 3600;
 
 /// Cached version check result.
 #[derive(Clone)]
-pub(crate) struct CachedCheck {
+pub struct CachedCheck {
     result: VersionCheckResponse,
     fetched_at: std::time::Instant,
 }

--- a/server/tests/memory_bd.rs
+++ b/server/tests/memory_bd.rs
@@ -178,6 +178,22 @@ async fn test_memory_bd_round_trip() {
     let entries: Vec<serde_json::Value> = resp.json().await.unwrap();
     assert!(entries.is_empty(), "expected empty after delete, got: {entries:?}");
 
+    // -- Auto-gen key: PUT with empty key must return a non-empty bd-generated key --
+    let resp = client
+        .put(format!("{}/api/memory", base))
+        .json(&serde_json::json!({
+            "path": &tmp_str,
+            "key": "",
+            "content": "auto generated key test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "auto-gen PUT should return 200");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let auto_key = body["key"].as_str().unwrap_or("");
+    assert!(!auto_key.is_empty(), "auto-gen key must be non-empty, got: {body:?}");
+
     // 5. Cleanup
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/server/tests/memory_bd.rs
+++ b/server/tests/memory_bd.rs
@@ -1,0 +1,183 @@
+//! Integration tests for the bd-backed memory API.
+//!
+//! Requires `bd` CLI to be on PATH. If not found, the test prints a note and
+//! returns early so CI environments without bd don't fail.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_tmp_dir() -> std::path::PathBuf {
+    // Must be under $HOME because validate_path_security restricts to home dir.
+    // macOS $TMPDIR is /var/folders/... which is outside home.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    std::path::PathBuf::from(home).join(format!(".tmp_memory_bd_test_{}", nanos))
+}
+
+/// Spin up the axum router on a random port and return the base URL.
+async fn start_test_server() -> String {
+    use axum::{routing::get, Router};
+
+    // We need to import from the server crate — but since this is an integration
+    // test we call the server binary's logic. However the server crate doesn't
+    // expose a `build_router` fn. The simplest approach is to construct a minimal
+    // router in-test that wires the same handlers.
+    let app = Router::new().route(
+        "/api/memory",
+        get(beads_server::routes::memory::list_memory)
+            .put(beads_server::routes::memory::update_memory)
+            .delete(beads_server::routes::memory::delete_memory),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://127.0.0.1:{}", port)
+}
+
+#[tokio::test]
+async fn test_memory_bd_round_trip() {
+    // 1. Create tmp dir
+    let tmp = unique_tmp_dir();
+    std::fs::create_dir_all(&tmp).unwrap();
+    let tmp_str = tmp.to_str().unwrap().to_string();
+
+    // 2. git init then bd init — skip if either tool is missing or fails
+    let git_init = std::process::Command::new("git")
+        .args(["init", &tmp_str])
+        .output();
+
+    match git_init {
+        Ok(o) if o.status.success() => {}
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            println!("git init failed: {stderr}, skipping test");
+            let _ = std::fs::remove_dir_all(&tmp);
+            return;
+        }
+        Err(e) => {
+            println!("git not on PATH ({e}), skipping memory_bd integration test");
+            let _ = std::fs::remove_dir_all(&tmp);
+            return;
+        }
+    }
+
+    // bd init must run with cwd=tmp (it doesn't support -C for init)
+    let init_result = std::process::Command::new("bd")
+        .arg("init")
+        .current_dir(&tmp)
+        .output();
+
+    let init_output = match init_result {
+        Ok(o) => o,
+        Err(e) => {
+            println!("bd not on PATH ({e}), skipping memory_bd integration test");
+            let _ = std::fs::remove_dir_all(&tmp);
+            return;
+        }
+    };
+
+    if !init_output.status.success() {
+        let stderr = String::from_utf8_lossy(&init_output.stderr);
+        println!("bd init failed: {stderr}, skipping test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        return;
+    }
+
+    // 3. Start test server
+    let base = start_test_server().await;
+    let client = reqwest::Client::new();
+
+    // -- List → empty --
+    let resp = client
+        .get(format!("{}/api/memory?path={}", base, &tmp_str))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "list should return 200");
+    let entries: Vec<serde_json::Value> = resp.json().await.unwrap();
+    assert!(
+        entries.is_empty(),
+        "expected empty list, got: {entries:?}"
+    );
+
+    // -- Update: create test-key --
+    let resp = client
+        .put(format!("{}/api/memory", base))
+        .json(&serde_json::json!({
+            "path": &tmp_str,
+            "key": "test-key",
+            "content": "hello"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "update (create) should return 200");
+
+    // -- List → contains test-key with content "hello" --
+    let resp = client
+        .get(format!("{}/api/memory?path={}", base, &tmp_str))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let entries: Vec<serde_json::Value> = resp.json().await.unwrap();
+    assert_eq!(entries.len(), 1, "expected 1 entry, got: {entries:?}");
+    assert_eq!(entries[0]["key"], "test-key");
+    assert_eq!(entries[0]["content"], "hello");
+
+    // -- Update: overwrite test-key with "updated" --
+    let resp = client
+        .put(format!("{}/api/memory", base))
+        .json(&serde_json::json!({
+            "path": &tmp_str,
+            "key": "test-key",
+            "content": "updated"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "update (overwrite) should return 200");
+
+    // -- List → content is "updated" --
+    let resp = client
+        .get(format!("{}/api/memory?path={}", base, &tmp_str))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let entries: Vec<serde_json::Value> = resp.json().await.unwrap();
+    assert_eq!(entries.len(), 1, "expected 1 entry after update");
+    assert_eq!(entries[0]["content"], "updated");
+
+    // -- Delete test-key --
+    let resp = client
+        .delete(format!("{}/api/memory", base))
+        .json(&serde_json::json!({
+            "path": &tmp_str,
+            "key": "test-key"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "delete should return 200");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["success"], true);
+
+    // -- List → empty again --
+    let resp = client
+        .get(format!("{}/api/memory?path={}", base, &tmp_str))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let entries: Vec<serde_json::Value> = resp.json().await.unwrap();
+    assert!(entries.is_empty(), "expected empty after delete, got: {entries:?}");
+
+    // 5. Cleanup
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/app/project/kanban-board.tsx
+++ b/src/app/project/kanban-board.tsx
@@ -234,13 +234,6 @@ export default function KanbanBoard() {
     }
   }, [projectId, router]);
 
-  /**
-   * Handle navigation from Memory panel to a bead
-   */
-  const handleMemoryNavigateToBead = useCallback((beadId: string) => {
-    setIsMemoryOpen(false);
-    navigateToBead(beadId);
-  }, [navigateToBead]);
 
   // Redirect state while no project ID
   if (!projectId) {
@@ -428,7 +421,6 @@ export default function KanbanBoard() {
           open={isMemoryOpen}
           onOpenChange={setIsMemoryOpen}
           projectPath={fsPath}
-          onNavigateToBead={handleMemoryNavigateToBead}
         />
       )}
       </ErrorBoundary>

--- a/src/components/create-memory-dialog.tsx
+++ b/src/components/create-memory-dialog.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface CreateMemoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreate: (content: string, key?: string) => Promise<void>;
+}
+
+export function CreateMemoryDialog({
+  open,
+  onOpenChange,
+  onCreate,
+}: CreateMemoryDialogProps) {
+  const [key, setKey] = useState("");
+  const [content, setContent] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setKey("");
+    setContent("");
+    setError(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) resetForm();
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, resetForm]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      setError("Content is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onCreate(trimmedContent, key.trim() || undefined);
+      handleOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save memory");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [content, key, onCreate, handleOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg bg-surface-raised border-b-default">
+        <DialogHeader>
+          <DialogTitle className="text-t-primary">Remember</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-1.5">
+            <label htmlFor="memory-key" className="text-sm font-medium text-t-secondary">
+              Key <span className="text-t-faint font-normal">(optional)</span>
+            </label>
+            <Input
+              id="memory-key"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              placeholder="(auto-generated if blank)"
+              className="bg-surface-overlay/50 border-b-strong text-t-primary placeholder:text-t-muted font-mono text-sm"
+            />
+            <p className="text-xs text-t-faint">
+              Use the same key later to update in place
+            </p>
+          </div>
+
+          <div className="grid gap-1.5">
+            <label htmlFor="memory-content" className="text-sm font-medium text-t-secondary">
+              Content
+            </label>
+            <textarea
+              id="memory-content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="What should be remembered?"
+              rows={5}
+              autoFocus
+              className="flex w-full rounded-md border border-b-strong bg-surface-overlay/50 px-3 py-2 text-sm text-t-primary placeholder:text-t-muted ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 resize-y"
+            />
+          </div>
+
+          {error && <p className="text-sm text-danger">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => handleOpenChange(false)}
+            disabled={isSubmitting}
+            className="text-t-secondary"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting || !content.trim()}
+            className="bg-accent text-accent-foreground hover:bg-accent/90"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/memory-panel.tsx
+++ b/src/components/memory-panel.tsx
@@ -5,9 +5,7 @@ import { useState, useCallback } from "react";
 import {
   BrainCircuit,
   Pencil,
-  Tag,
-  ExternalLink,
-  Archive,
+  Plus,
   Trash2,
   Search,
   MoreVertical,
@@ -15,6 +13,7 @@ import {
   Loader2,
 } from "lucide-react";
 
+import { CreateMemoryDialog } from "@/components/create-memory-dialog";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -24,7 +23,6 @@ import {
   AlertDialogTitle,
   AlertDialogClose,
 } from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -41,12 +39,9 @@ import {
   SheetHeader,
   SheetTitle,
   SheetDescription,
-  SheetFooter,
 } from "@/components/ui/sheet";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useMemory } from "@/hooks/use-memory";
-import { cn } from "@/lib/utils";
-import type { MemoryEntry, MemoryType } from "@/types";
+import type { MemoryEntry } from "@/types";
 
 export interface MemoryPanelProps {
   /** Whether the panel is open */
@@ -55,303 +50,54 @@ export interface MemoryPanelProps {
   onOpenChange: (open: boolean) => void;
   /** Absolute path to the project root */
   projectPath: string;
-  /** Callback to navigate to a bead by ID */
-  onNavigateToBead?: (beadId: string) => void;
-}
-
-type TabFilter = "all" | "learned" | "investigation";
-
-/**
- * Format a unix timestamp to a relative time string
- */
-function formatRelativeTime(ts: number): string {
-  const now = Date.now() / 1000;
-  const diff = now - ts;
-
-  if (diff < 60) return "just now";
-  if (diff < 3600) {
-    const mins = Math.floor(diff / 60);
-    return `${mins}m ago`;
-  }
-  if (diff < 86400) {
-    const hours = Math.floor(diff / 3600);
-    return `${hours}h ago`;
-  }
-  if (diff < 604800) {
-    const days = Math.floor(diff / 86400);
-    return `${days}d ago`;
-  }
-  const date = new Date(ts * 1000);
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
 }
 
 /**
- * Format a memory entry's bead ID to a short display form.
- * Handles IDs like "beads-kanban-ui-t25.2" -> "BD-t25.2"
- * or "project-p02" -> "BD-p02"
+ * Memory Panel - slide-out Sheet for browsing and managing bd memory entries
  */
-function formatMemoryBeadId(id: string): string {
-  if (id.startsWith("BD-") || id.startsWith("bd-")) {
-    return id.length > 10 ? `BD-${id.slice(-6)}` : id.toUpperCase();
-  }
-  // Extract the part after the last hyphen (handles dots for epic children)
-  const lastDash = id.lastIndexOf("-");
-  if (lastDash !== -1) {
-    return `BD-${id.slice(lastDash + 1)}`;
-  }
-  return `BD-${id.slice(0, 6)}`;
-}
-
-/**
- * Single memory entry card
- */
-function MemoryEntryCard({
-  entry,
-  onEdit,
-  onArchive,
-  onDelete,
-  onNavigate,
-}: {
-  entry: MemoryEntry;
-  onEdit: (entry: MemoryEntry) => void;
-  onArchive: (key: string) => void;
-  onDelete: (key: string) => void;
-  onNavigate?: (beadId: string) => void;
-}) {
-  return (
-    <div className="rounded-lg border border-b-default bg-surface-raised/50 p-3 space-y-2 overflow-hidden">
-      {/* Top row: type badge, timestamp */}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          {entry.type === "learned" ? (
-            <Badge variant="info" appearance="light" size="xs">
-              LEARN
-            </Badge>
-          ) : (
-            <Badge variant="success" appearance="light" size="xs">
-              INVES
-            </Badge>
-          )}
-        </div>
-        <time
-          dateTime={new Date(entry.ts * 1000).toISOString()}
-          className="text-xs text-t-faint shrink-0 tabular-nums"
-          suppressHydrationWarning
-        >
-          {formatRelativeTime(entry.ts)}
-        </time>
-      </div>
-
-      {/* Content preview */}
-      <p className="text-sm text-t-secondary line-clamp-3 text-pretty">
-        {entry.content}
-      </p>
-
-      {/* Bottom row: tags, bead link, actions menu */}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
-          {entry.tags.slice(0, 3).map((tag) => (
-            <Badge
-              key={tag}
-              variant="secondary"
-              appearance="light"
-              size="xs"
-              className="text-t-muted"
-            >
-              {tag}
-            </Badge>
-          ))}
-          {entry.tags.length > 3 && (
-            <span className="text-xs text-t-faint shrink-0">
-              +{entry.tags.length - 3}
-            </span>
-          )}
-        </div>
-
-        <div className="flex items-center gap-1.5 shrink-0">
-          {entry.bead && (
-            <button
-              type="button"
-              onClick={() => onNavigate?.(entry.bead)}
-              className={cn(
-                "text-xs font-mono text-t-muted hover:text-t-secondary transition-colors rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring truncate max-w-[120px]",
-                !onNavigate && "pointer-events-none"
-              )}
-              title={entry.bead}
-              aria-label={`Navigate to bead ${entry.bead}`}
-            >
-              {formatMemoryBeadId(entry.bead)}
-            </button>
-          )}
-
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="size-6 flex items-center justify-center rounded text-t-muted hover:text-t-secondary hover:bg-surface-overlay transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                aria-label="Entry actions"
-              >
-                <MoreVertical className="size-3.5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="bg-surface-raised border-b-default"
-            >
-              <DropdownMenuItem
-                onClick={() => onEdit(entry)}
-                className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary gap-2"
-              >
-                <Pencil className="size-3.5" aria-hidden="true" />
-                Edit content
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => onEdit(entry)}
-                className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary gap-2"
-              >
-                <Tag className="size-3.5" aria-hidden="true" />
-                Edit tags
-              </DropdownMenuItem>
-              {entry.bead && onNavigate && (
-                <DropdownMenuItem
-                  onClick={() => onNavigate(entry.bead)}
-                  className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary gap-2"
-                >
-                  <ExternalLink className="size-3.5" aria-hidden="true" />
-                  Navigate to bead
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuSeparator className="bg-surface-overlay" />
-              <DropdownMenuItem
-                onClick={() => onArchive(entry.key)}
-                className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary gap-2"
-              >
-                <Archive className="size-3.5" aria-hidden="true" />
-                Archive
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => onDelete(entry.key)}
-                className="text-danger focus:bg-surface-overlay focus:text-danger gap-2"
-              >
-                <Trash2 className="size-3.5" aria-hidden="true" />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/**
- * Memory Panel - slide-out Sheet for browsing and managing knowledge base entries
- */
-export function MemoryPanel({
-  open,
-  onOpenChange,
-  projectPath,
-  onNavigateToBead,
-}: MemoryPanelProps) {
+export function MemoryPanel({ open, onOpenChange, projectPath }: MemoryPanelProps) {
   const {
-    stats,
+    entries,
     isLoading,
     error,
     search,
     setSearch,
-    typeFilter,
-    setTypeFilter,
     filteredEntries,
+    createEntry,
     editEntry,
-    archiveEntry,
     deleteEntry,
   } = useMemory(projectPath);
 
-  // Tab state maps to type filter
-  const [activeTab, setActiveTab] = useState<TabFilter>("all");
+  // Create dialog state
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
 
   // Edit dialog state
   const [editingEntry, setEditingEntry] = useState<MemoryEntry | null>(null);
   const [editContent, setEditContent] = useState("");
-  const [editTags, setEditTags] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
   // Delete confirmation state
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  /**
-   * Handle tab change - maps tab value to type filter
-   */
-  const handleTabChange = useCallback(
-    (value: string) => {
-      const tabValue = value as TabFilter;
-      setActiveTab(tabValue);
-      setTypeFilter(tabValue === "all" ? null : (tabValue as MemoryType));
-    },
-    [setTypeFilter]
-  );
-
-  /**
-   * Handle navigate to bead
-   */
-  const handleNavigate = useCallback(
-    (beadId: string) => {
-      onOpenChange(false);
-      onNavigateToBead?.(beadId);
-    },
-    [onOpenChange, onNavigateToBead]
-  );
-
-  /**
-   * Open edit dialog for an entry
-   */
   const handleEditOpen = useCallback((entry: MemoryEntry) => {
     setEditingEntry(entry);
     setEditContent(entry.content);
-    setEditTags(entry.tags.join(", "));
   }, []);
 
-  /**
-   * Save edited entry
-   */
   const handleEditSave = useCallback(async () => {
     if (!editingEntry) return;
     setIsSaving(true);
     try {
-      const newTags = editTags
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean);
-      await editEntry(editingEntry.key, editContent, newTags);
+      await editEntry(editingEntry.key, editContent);
       setEditingEntry(null);
     } catch {
       // Error is logged in hook
     } finally {
       setIsSaving(false);
     }
-  }, [editingEntry, editContent, editTags, editEntry]);
+  }, [editingEntry, editContent, editEntry]);
 
-  /**
-   * Handle archive
-   */
-  const handleArchive = useCallback(
-    async (key: string) => {
-      try {
-        await archiveEntry(key);
-      } catch {
-        // Error is logged in hook
-      }
-    },
-    [archiveEntry]
-  );
-
-  /**
-   * Handle delete confirmation
-   */
   const handleDeleteConfirm = useCallback(async () => {
     if (!deletingKey) return;
     setIsDeleting(true);
@@ -373,14 +119,22 @@ export function MemoryPanel({
           className="w-full sm:max-w-lg md:max-w-xl bg-surface-base border-b-default flex flex-col"
         >
           <SheetHeader className="space-y-1">
-            <SheetTitle className="flex items-center gap-2 text-t-primary">
-              <BrainCircuit className="size-5" aria-hidden="true" />
-              Memory
-            </SheetTitle>
+            <div className="flex items-center justify-between">
+              <SheetTitle className="flex items-center gap-2 text-t-primary">
+                <BrainCircuit className="size-5" aria-hidden="true" />
+                Memory
+              </SheetTitle>
+              <button
+                type="button"
+                onClick={() => setIsCreateOpen(true)}
+                className="size-7 flex items-center justify-center rounded text-t-muted hover:text-t-secondary hover:bg-surface-overlay transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                aria-label="Remember something new"
+              >
+                <Plus className="size-4" />
+              </button>
+            </div>
             <SheetDescription className="text-t-muted">
-              {stats
-                ? `${stats.total} ${stats.total === 1 ? "entry" : "entries"}`
-                : "Loading..."}
+              {isLoading ? "Loading..." : `${entries.length} ${entries.length === 1 ? "entry" : "entries"}`}
             </SheetDescription>
           </SheetHeader>
 
@@ -410,34 +164,6 @@ export function MemoryPanel({
             )}
           </div>
 
-          {/* Type filter tabs */}
-          <Tabs
-            value={activeTab}
-            onValueChange={handleTabChange}
-            className="mt-3"
-          >
-            <TabsList className="h-8 bg-surface-overlay/50 p-0.5 w-full">
-              <TabsTrigger
-                value="all"
-                className="h-7 flex-1 text-sm font-medium data-[state=active]:bg-surface-overlay data-[state=active]:text-t-primary data-[state=inactive]:text-t-tertiary"
-              >
-                All
-              </TabsTrigger>
-              <TabsTrigger
-                value="learned"
-                className="h-7 flex-1 text-sm font-medium data-[state=active]:bg-surface-overlay data-[state=active]:text-t-primary data-[state=inactive]:text-t-tertiary"
-              >
-                Learned
-              </TabsTrigger>
-              <TabsTrigger
-                value="investigation"
-                className="h-7 flex-1 text-sm font-medium data-[state=active]:bg-surface-overlay data-[state=active]:text-t-primary data-[state=inactive]:text-t-tertiary"
-              >
-                Investigation
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-
           {/* Entries list */}
           <ScrollArea className="flex-1 mt-3 -mx-6 px-6">
             <div className="space-y-2 pb-4">
@@ -451,77 +177,87 @@ export function MemoryPanel({
                   role="alert"
                   className="rounded-lg border border-danger/30 bg-danger/10 p-4 text-center"
                 >
-                  <p className="text-sm text-danger">
-                    Failed to load memory entries
-                  </p>
-                  <p className="text-xs text-danger/60 mt-1">
-                    {error.message}
-                  </p>
+                  <p className="text-sm text-danger">Failed to load memory entries</p>
+                  <p className="text-xs text-danger/60 mt-1">{error.message}</p>
                 </div>
               ) : filteredEntries.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <BrainCircuit
-                    className="size-8 text-t-faint mb-3"
-                    aria-hidden="true"
-                  />
+                  <BrainCircuit className="size-8 text-t-faint mb-3" aria-hidden="true" />
                   <p className="text-sm text-t-muted">
-                    {search || typeFilter
-                      ? "No entries match your search"
-                      : "No memory entries yet"}
+                    {search ? "No entries match your search" : "No memory entries yet"}
                   </p>
-                  {(search || typeFilter) && (
+                  {search && (
                     <button
                       type="button"
-                      onClick={() => {
-                        setSearch("");
-                        setActiveTab("all");
-                        setTypeFilter(null);
-                      }}
+                      onClick={() => setSearch("")}
                       className="mt-2 text-xs text-t-muted hover:text-t-secondary underline underline-offset-2 rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     >
-                      Clear filters
+                      Clear search
                     </button>
                   )}
                 </div>
               ) : (
                 filteredEntries.map((entry) => (
-                  <MemoryEntryCard
+                  <div
                     key={entry.key}
-                    entry={entry}
-                    onEdit={handleEditOpen}
-                    onArchive={handleArchive}
-                    onDelete={setDeletingKey}
-                    onNavigate={onNavigateToBead ? handleNavigate : undefined}
-                  />
+                    className="rounded-lg border border-b-default bg-surface-raised/50 p-3 space-y-1.5 overflow-hidden"
+                  >
+                    {/* Key badge + actions row */}
+                    <div className="flex items-center justify-between gap-2">
+                      <code className="text-xs font-mono text-t-muted bg-surface-overlay px-1.5 py-0.5 rounded truncate max-w-[calc(100%-2rem)]">
+                        {entry.key}
+                      </code>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="size-6 flex items-center justify-center rounded text-t-muted hover:text-t-secondary hover:bg-surface-overlay transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring shrink-0"
+                            aria-label="Entry actions"
+                          >
+                            <MoreVertical className="size-3.5" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          className="bg-surface-raised border-b-default"
+                        >
+                          <DropdownMenuItem
+                            onClick={() => handleEditOpen(entry)}
+                            className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary gap-2"
+                          >
+                            <Pencil className="size-3.5" aria-hidden="true" />
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator className="bg-surface-overlay" />
+                          <DropdownMenuItem
+                            onClick={() => setDeletingKey(entry.key)}
+                            className="text-danger focus:bg-surface-overlay focus:text-danger gap-2"
+                          >
+                            <Trash2 className="size-3.5" aria-hidden="true" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+
+                    {/* Content */}
+                    <p className="text-sm text-t-secondary line-clamp-3 text-pretty">
+                      {entry.content}
+                    </p>
+                  </div>
                 ))
               )}
             </div>
           </ScrollArea>
-
-          {/* Footer stats */}
-          {stats && stats.total > 0 && (
-            <SheetFooter className="border-t border-b-default pt-3 -mx-6 px-6">
-              <p className="text-xs text-t-faint w-full text-center">
-                <span className="tabular-nums">{stats.learned}</span> learned
-                <span className="mx-1.5" aria-hidden="true">
-                  ·
-                </span>
-                <span className="tabular-nums">{stats.investigation}</span>{" "}
-                investigation
-                {stats.archived > 0 && (
-                  <>
-                    <span className="mx-1.5" aria-hidden="true">
-                      ·
-                    </span>
-                    <span className="tabular-nums">{stats.archived}</span>{" "}
-                    archived
-                  </>
-                )}
-              </p>
-            </SheetFooter>
-          )}
         </SheetContent>
       </Sheet>
+
+      {/* Create Dialog */}
+      <CreateMemoryDialog
+        open={isCreateOpen}
+        onOpenChange={setIsCreateOpen}
+        onCreate={createEntry}
+      />
 
       {/* Edit Dialog */}
       <AlertDialog
@@ -534,39 +270,22 @@ export function MemoryPanel({
               Edit Memory Entry
             </AlertDialogTitle>
             <AlertDialogDescription className="text-t-muted">
-              Update the content or tags for this entry.
+              <code className="font-mono text-xs">{editingEntry?.key}</code>
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <div className="space-y-4 py-2">
-            <div className="space-y-2">
-              <label
-                htmlFor="edit-content"
-                className="text-sm font-medium text-t-secondary"
-              >
-                Content
-              </label>
-              <textarea
-                id="edit-content"
-                value={editContent}
-                onChange={(e) => setEditContent(e.target.value)}
-                className="w-full h-32 rounded-md border border-b-strong bg-surface-overlay/50 px-3 py-2 text-sm text-t-primary placeholder:text-t-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
-              />
-            </div>
-            <div className="space-y-2">
-              <label
-                htmlFor="edit-tags"
-                className="text-sm font-medium text-t-secondary"
-              >
-                Tags (comma-separated)
-              </label>
-              <Input
-                id="edit-tags"
-                value={editTags}
-                onChange={(e) => setEditTags(e.target.value)}
-                className="bg-surface-overlay/50 border-b-strong text-t-primary placeholder:text-t-muted"
-                placeholder="tag1, tag2, tag3..."
-              />
-            </div>
+          <div className="space-y-2 py-2">
+            <label
+              htmlFor="edit-content"
+              className="text-sm font-medium text-t-secondary"
+            >
+              Content
+            </label>
+            <textarea
+              id="edit-content"
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              className="w-full h-32 rounded-md border border-b-strong bg-surface-overlay/50 px-3 py-2 text-sm text-t-primary placeholder:text-t-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
+            />
           </div>
           <AlertDialogFooter>
             <AlertDialogClose render={<Button variant="ghost">Cancel</Button>} />
@@ -591,8 +310,7 @@ export function MemoryPanel({
               Delete Memory Entry
             </AlertDialogTitle>
             <AlertDialogDescription className="text-t-tertiary">
-              This will permanently delete this memory entry. This action cannot
-              be undone. Consider archiving instead.
+              This will permanently delete this memory entry. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/memory-panel.tsx
+++ b/src/components/memory-panel.tsx
@@ -119,20 +119,10 @@ export function MemoryPanel({ open, onOpenChange, projectPath }: MemoryPanelProp
           className="w-full sm:max-w-lg md:max-w-xl bg-surface-base border-b-default flex flex-col"
         >
           <SheetHeader className="space-y-1">
-            <div className="flex items-center justify-between">
-              <SheetTitle className="flex items-center gap-2 text-t-primary">
-                <BrainCircuit className="size-5" aria-hidden="true" />
-                Memory
-              </SheetTitle>
-              <button
-                type="button"
-                onClick={() => setIsCreateOpen(true)}
-                className="size-7 flex items-center justify-center rounded text-t-muted hover:text-t-secondary hover:bg-surface-overlay transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                aria-label="Remember something new"
-              >
-                <Plus className="size-4" />
-              </button>
-            </div>
+            <SheetTitle className="flex items-center gap-2 text-t-primary">
+              <BrainCircuit className="size-5" aria-hidden="true" />
+              Memory
+            </SheetTitle>
             <SheetDescription className="text-t-muted">
               {isLoading ? "Loading..." : `${entries.length} ${entries.length === 1 ? "entry" : "entries"}`}
             </SheetDescription>
@@ -163,6 +153,16 @@ export function MemoryPanel({ open, onOpenChange, projectPath }: MemoryPanelProp
               </button>
             )}
           </div>
+
+          {/* Add Memory button */}
+          <button
+            type="button"
+            onClick={() => setIsCreateOpen(true)}
+            className="mt-2 w-full flex items-center justify-center gap-1.5 h-8 rounded border border-b-strong bg-surface-overlay/50 text-sm text-t-secondary hover:text-t-primary hover:bg-surface-overlay transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <Plus className="size-4" aria-hidden="true" />
+            Add Memory
+          </button>
 
           {/* Entries list */}
           <ScrollArea className="flex-1 mt-3 -mx-6 px-6">

--- a/src/hooks/use-memory.ts
+++ b/src/hooks/use-memory.ts
@@ -1,23 +1,19 @@
 "use client";
 
 /**
- * Hook for loading and managing memory entries (knowledge base).
+ * Hook for loading and managing memory entries (bd memories).
  *
- * Fetches from GET /api/memory and provides search, filter,
- * edit, archive, and delete capabilities.
+ * Fetches from GET /api/memory and provides search, create, edit, and delete.
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 
 import * as api from "@/lib/api";
-import { isDoltProject } from "@/lib/utils";
-import type { MemoryEntry, MemoryStats, MemoryType } from "@/types";
+import type { MemoryEntry } from "@/types";
 
 export interface UseMemoryResult {
   /** All memory entries from the project */
   entries: MemoryEntry[];
-  /** Aggregate stats */
-  stats: MemoryStats | null;
   /** Whether entries are currently being loaded */
   isLoading: boolean;
   /** Any error that occurred during loading */
@@ -26,66 +22,45 @@ export interface UseMemoryResult {
   search: string;
   /** Set search query */
   setSearch: (value: string) => void;
-  /** Current type filter (null = all) */
-  typeFilter: MemoryType | null;
-  /** Set type filter */
-  setTypeFilter: (value: MemoryType | null) => void;
-  /** Entries filtered by search and type */
+  /** Entries filtered by search substring on key+content */
   filteredEntries: MemoryEntry[];
-  /** Edit an entry's content and/or tags */
-  editEntry: (key: string, content?: string, tags?: string[]) => Promise<void>;
-  /** Archive an entry (move to archive file) */
-  archiveEntry: (key: string) => Promise<void>;
+  /** Create a new entry; omit key to auto-generate */
+  createEntry: (content: string, key?: string) => Promise<void>;
+  /** Edit an entry's content */
+  editEntry: (key: string, content: string) => Promise<void>;
   /** Permanently delete an entry */
   deleteEntry: (key: string) => Promise<void>;
   /** Manually refresh entries */
   refresh: () => Promise<void>;
 }
 
-const EMPTY_STATS: MemoryStats = {
-  total: 0,
-  learned: 0,
-  investigation: 0,
-  archived: 0,
-};
-
 /**
- * Hook to load and manage memory entries from a project's knowledge base.
+ * Hook to load and manage memory entries from a project's bd knowledge base.
  *
  * @param projectPath - The absolute path to the project root
- * @returns Object containing entries, stats, filters, mutations, and refresh
  */
 export function useMemory(projectPath: string): UseMemoryResult {
   const [entries, setEntries] = useState<MemoryEntry[]>([]);
-  const [stats, setStats] = useState<MemoryStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [search, setSearch] = useState("");
-  const [typeFilter, setTypeFilter] = useState<MemoryType | null>(null);
 
-  // Track if initial load has completed
   const hasLoadedRef = useRef(false);
 
-  /**
-   * Load memory entries from the API
-   */
   const loadMemory = useCallback(async () => {
-    if (!projectPath || isDoltProject(projectPath)) {
+    if (!projectPath) {
       setEntries([]);
-      setStats(EMPTY_STATS);
       setIsLoading(false);
       return;
     }
 
-    // Only show loading on initial load
     if (!hasLoadedRef.current) {
       setIsLoading(true);
     }
 
     try {
-      const response = await api.memory.list(projectPath);
-      setEntries(response.entries);
-      setStats(response.stats);
+      const data = await api.memory.list(projectPath);
+      setEntries(data);
       setError(null);
       hasLoadedRef.current = true;
     } catch (err) {
@@ -97,53 +72,44 @@ export function useMemory(projectPath: string): UseMemoryResult {
     }
   }, [projectPath]);
 
-  /**
-   * Public refresh function
-   */
   const refresh = useCallback(async () => {
     await loadMemory();
   }, [loadMemory]);
 
-  // Initial load when project path changes
   useEffect(() => {
     hasLoadedRef.current = false;
     loadMemory();
   }, [loadMemory]);
 
-  /**
-   * Filter entries by search query and type
-   */
   const filteredEntries = useMemo(() => {
-    let result = entries;
+    if (!search.trim()) return entries;
+    const s = search.toLowerCase();
+    return entries.filter(
+      (e) =>
+        e.key.toLowerCase().includes(s) || e.content.toLowerCase().includes(s)
+    );
+  }, [entries, search]);
 
-    // Apply type filter
-    if (typeFilter) {
-      result = result.filter((e) => e.type === typeFilter);
-    }
-
-    // Apply search filter
-    if (search.trim()) {
-      const query = search.toLowerCase();
-      result = result.filter(
-        (e) =>
-          e.content.toLowerCase().includes(query) ||
-          e.key.toLowerCase().includes(query) ||
-          e.tags.some((t) => t.toLowerCase().includes(query)) ||
-          e.bead.toLowerCase().includes(query)
-      );
-    }
-
-    return result;
-  }, [entries, search, typeFilter]);
-
-  /**
-   * Edit an entry's content and/or tags
-   */
-  const editEntry = useCallback(
-    async (key: string, content?: string, tags?: string[]) => {
+  const createEntry = useCallback(
+    async (content: string, key?: string) => {
       if (!projectPath) return;
       try {
-        await api.memory.update(projectPath, key, content, tags);
+        await api.memory.update(projectPath, key ?? "", content);
+        await loadMemory();
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error("Failed to create memory entry:", error);
+        throw error;
+      }
+    },
+    [projectPath, loadMemory]
+  );
+
+  const editEntry = useCallback(
+    async (key: string, content: string) => {
+      if (!projectPath) return;
+      try {
+        await api.memory.update(projectPath, key, content);
         await loadMemory();
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
@@ -154,32 +120,11 @@ export function useMemory(projectPath: string): UseMemoryResult {
     [projectPath, loadMemory]
   );
 
-  /**
-   * Archive an entry
-   */
-  const archiveEntry = useCallback(
-    async (key: string) => {
-      if (!projectPath) return;
-      try {
-        await api.memory.remove(projectPath, key, true);
-        await loadMemory();
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        console.error("Failed to archive memory entry:", error);
-        throw error;
-      }
-    },
-    [projectPath, loadMemory]
-  );
-
-  /**
-   * Permanently delete an entry
-   */
   const deleteEntry = useCallback(
     async (key: string) => {
       if (!projectPath) return;
       try {
-        await api.memory.remove(projectPath, key, false);
+        await api.memory.remove(projectPath, key);
         await loadMemory();
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
@@ -192,16 +137,13 @@ export function useMemory(projectPath: string): UseMemoryResult {
 
   return {
     entries,
-    stats,
     isLoading,
     error,
     search,
     setSearch,
-    typeFilter,
-    setTypeFilter,
     filteredEntries,
+    createEntry,
     editEntry,
-    archiveEntry,
     deleteEntry,
     refresh,
   };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,7 +4,7 @@
  */
 
 import { BeadsResponseSchema, PRStatusSchema, WorktreeStatusSchema } from '@/lib/api-schemas';
-import type { Project, Tag, Bead, WorktreeStatus, WorktreeEntry, PRStatus, PRFilesResponse, MemoryResponse, MemoryStats, MemoryEntry, Agent, AgentModel } from '@/types';
+import type { Project, Tag, Bead, WorktreeStatus, WorktreeEntry, PRStatus, PRFilesResponse, MemoryEntry, Agent, AgentModel } from '@/types';
 
 const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3008';
 
@@ -358,28 +358,23 @@ export const fs = {
  * Memory API
  */
 export const memory = {
-  /** Fetch all memory entries and stats */
-  list: (path: string) => fetchApi<MemoryResponse>(
+  /** Fetch all memory entries */
+  list: (path: string) => fetchApi<MemoryEntry[]>(
     `/api/memory?path=${encodeURIComponent(path)}`
   ),
 
-  /** Fetch memory stats only (lightweight) */
-  stats: (path: string) => fetchApi<MemoryStats>(
-    `/api/memory/stats?path=${encodeURIComponent(path)}`
-  ),
-
-  /** Update an entry's content and/or tags */
-  update: (path: string, key: string, content?: string, tags?: string[]) =>
-    fetchApi<{ success: boolean; entry: MemoryEntry }>('/api/memory', {
+  /** Create or upsert a memory entry (empty key = auto-generate) */
+  update: (path: string, key: string, content: string) =>
+    fetchApi<MemoryEntry>('/api/memory', {
       method: 'PUT',
-      body: JSON.stringify({ path, key, content, tags }),
+      body: JSON.stringify({ path, key, content }),
     }),
 
-  /** Delete or archive an entry */
-  remove: (path: string, key: string, archive: boolean) =>
-    fetchApi<{ success: boolean; archived: boolean }>('/api/memory', {
+  /** Delete a memory entry */
+  remove: (path: string, key: string) =>
+    fetchApi<{ success: boolean }>('/api/memory', {
       method: 'DELETE',
-      body: JSON.stringify({ path, key, archive }),
+      body: JSON.stringify({ path, key }),
     }),
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -326,39 +326,11 @@ export interface PRFilesResponse {
 // ============================================================================
 
 /**
- * Memory entry type: learned insight or investigation context
- */
-export type MemoryType = "learned" | "investigation";
-
-/**
- * A single knowledge base entry from knowledge.jsonl
+ * A single memory entry from bd memories
  */
 export interface MemoryEntry {
   key: string;
-  type: MemoryType;
   content: string;
-  source: string;
-  tags: string[];
-  ts: number;
-  bead: string;
-}
-
-/**
- * Aggregate stats for the knowledge base
- */
-export interface MemoryStats {
-  total: number;
-  learned: number;
-  investigation: number;
-  archived: number;
-}
-
-/**
- * Response from GET /api/memory
- */
-export interface MemoryResponse {
-  entries: MemoryEntry[];
-  stats: MemoryStats;
 }
 
 // ============================================================================

--- a/tests/integration/run-tests.sh
+++ b/tests/integration/run-tests.sh
@@ -651,6 +651,83 @@ else:
     pass "$name"
 }
 
+# Test 21: Memory round-trip — PUT (create), GET, PUT (update), DELETE
+test_21_memory_round_trip() {
+    local name="Memory round-trip via /api/memory"
+
+    # PUT create
+    local s
+    s=$(curl -s -o /tmp/t21a.json -w "%{http_code}" \
+        -X PUT "${BASE_URL}/api/memory" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"${PROJECT_DIR}\",\"key\":\"int-test\",\"content\":\"hello\"}")
+    if [[ "$s" != "200" ]]; then
+        fail "$name" "PUT create expected 200, got $s"
+        return
+    fi
+
+    # GET — entry appears with content "hello"
+    s=$(curl -s -o /tmp/t21b.json -w "%{http_code}" "${BASE_URL}/api/memory?path=${PROJECT_DIR}")
+    if [[ "$s" != "200" ]]; then
+        fail "$name" "GET expected 200, got $s"
+        return
+    fi
+    if ! python3 -c "
+import json,sys
+d = json.load(open('/tmp/t21b.json'))
+e = next((x for x in d if x.get('key')=='int-test'), None)
+if not e or e.get('content') != 'hello': sys.exit(1)
+" 2>/dev/null; then
+        fail "$name" "create not visible in list"
+        return
+    fi
+
+    # PUT update — same key, new content
+    s=$(curl -s -o /tmp/t21c.json -w "%{http_code}" \
+        -X PUT "${BASE_URL}/api/memory" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"${PROJECT_DIR}\",\"key\":\"int-test\",\"content\":\"updated\"}")
+    if [[ "$s" != "200" ]]; then
+        fail "$name" "PUT update expected 200, got $s"
+        return
+    fi
+
+    # GET — content reflects update
+    curl -s -o /tmp/t21d.json "${BASE_URL}/api/memory?path=${PROJECT_DIR}"
+    if ! python3 -c "
+import json,sys
+d = json.load(open('/tmp/t21d.json'))
+e = next((x for x in d if x.get('key')=='int-test'), None)
+if not e or e.get('content') != 'updated': sys.exit(1)
+" 2>/dev/null; then
+        fail "$name" "update not reflected in list"
+        return
+    fi
+
+    # DELETE
+    s=$(curl -s -o /tmp/t21e.json -w "%{http_code}" \
+        -X DELETE "${BASE_URL}/api/memory" \
+        -H "Content-Type: application/json" \
+        -d "{\"path\":\"${PROJECT_DIR}\",\"key\":\"int-test\"}")
+    if [[ "$s" != "200" ]]; then
+        fail "$name" "DELETE expected 200, got $s"
+        return
+    fi
+
+    # GET — entry gone
+    curl -s -o /tmp/t21f.json "${BASE_URL}/api/memory?path=${PROJECT_DIR}"
+    if ! python3 -c "
+import json,sys
+d = json.load(open('/tmp/t21f.json'))
+if any(x.get('key')=='int-test' for x in d): sys.exit(1)
+" 2>/dev/null; then
+        fail "$name" "entry still visible after delete"
+        return
+    fi
+
+    pass "$name"
+}
+
 # ── Run all tests ─────────────────────────────────────────────────────────────
 
 test_1_get_beads
@@ -673,6 +750,7 @@ test_17_archive_project
 test_18_archived_hidden
 test_19_unarchive_project
 test_20_epic_with_children
+test_21_memory_round_trip
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "tests", "playwright.config.ts"]
+  "exclude": ["node_modules", "tests", "playwright.config.ts", "**/__tests__/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "tests", "playwright.config.ts", "**/__tests__/**"]
+  "exclude": ["node_modules", "tests", "playwright.config.ts"]
 }


### PR DESCRIPTION
The memory panel previously read `.beads/memory/knowledge.jsonl`, which is an orphan store: claude-protocol v3.3.0 removed the hooks that wrote to it, and `bd`'s own memory store (`bd remember/memories/forget`) lives in the Dolt DB. Surface that instead, so the panel reflects what `bd prime` injects into sessions.

- **Backend (`server/src/routes/memory.rs`)**: shells out to `bd memories --json` / `bd remember --key` / `bd forget`; `/api/memory/stats` removed
- **Frontend**: panel trimmed to bd flat schema (`{ key, content }`); `+ Remember` dialog for new entries; tabs/tags/timestamps/archive dropped
- **Tests**: new Rust integration test (`server/tests/memory_bd.rs`) spawns `bd` against a tmp project for a PUT → GET → PUT → DELETE → GET round-trip; Docker integration suite gets one new case (`test_21`)
- **Hygiene**: `__tests__/` typechecking restored, `@testing-library/dom` peer dep added; crate-level `#![allow(...)]` macros dropped (all six lint families now produce zero violations)

Hard cut — no migration. `.beads/memory/knowledge.jsonl` does not exist in this project. Upstream users with data lose UI visibility but the file is readable manually.