### PR TITLE
fix(ui): preserve bead prefix, real type label, correct dolt:// hint

### DIFF
--- a/src/components/bead-card.tsx
+++ b/src/components/bead-card.tsx
@@ -125,10 +125,15 @@ function getPRChecksDisplay(prStatus: PRStatus): { icon: React.ReactNode; text: 
 }
 
 /**
- * Get the display label for the bead type
+ * Get the display label for the bead type.
+ *
+ * Renders the actual `issue_type` (task, bug, feature, epic, story, spike,
+ * milestone, …) capitalized, instead of collapsing every non-epic type to
+ * "Task". Falls back to "Task" when the type is missing.
  */
 function getTypeLabel(bead: Bead): string {
-  return bead.issue_type === "epic" ? "Epic" : "Task";
+  const type = bead.issue_type ?? "task";
+  return type.charAt(0).toUpperCase() + type.slice(1);
 }
 
 /**

--- a/src/components/project-settings-dialog.tsx
+++ b/src/components/project-settings-dialog.tsx
@@ -236,7 +236,7 @@ export function ProjectSettingsDialog({
                     id="settings-dolt-source"
                     value={path}
                     onChange={(e) => setPath(e.target.value)}
-                    placeholder="dolt://host:port/database"
+                    placeholder="dolt://database_name"
                   />
                   {localPath && (
                     <Button

--- a/src/lib/__tests__/bead-utils.test.ts
+++ b/src/lib/__tests__/bead-utils.test.ts
@@ -11,22 +11,29 @@ import {
 } from '@/lib/bead-utils';
 
 describe('formatBeadId', () => {
-  it('uppercases BD- prefix IDs', () => {
-    expect(formatBeadId('bd-abc')).toBe('BD-ABC');
+  it('preserves and upper-cases the workspace prefix', () => {
+    expect(formatBeadId('pa-pne9')).toBe('PA-pne9');
+    expect(formatBeadId('dc-xyz')).toBe('DC-xyz');
+    expect(formatBeadId('beads-web-2m8')).toBe('BEADS-WEB-2m8');
+  });
+
+  it('handles the default bd prefix', () => {
+    expect(formatBeadId('bd-abc')).toBe('BD-abc');
     expect(formatBeadId('BD-ABC')).toBe('BD-ABC');
   });
 
-  it('truncates long BD- IDs to maxLen', () => {
-    expect(formatBeadId('bd-abcdefghijklm', 6)).toBe('BD-hijklm');
+  it('keeps the last segment as the short id for multi-dash ids', () => {
+    expect(formatBeadId('beads-kanban-ui-abc123')).toBe('BEADS-KANBAN-UI-abc123');
   });
 
-  it('extracts last segment for non-BD IDs', () => {
-    expect(formatBeadId('beads-kanban-ui-abc123')).toBe('BD-abc123');
+  it('truncates a long suffix to maxLen', () => {
+    expect(formatBeadId('bd-abcdefghijklm', 6)).toBe('BD-abcdef');
+    expect(formatBeadId('project-abcdefgh', 8)).toBe('PROJECT-abcdefgh');
+    expect(formatBeadId('project-abcdefgh', 4)).toBe('PROJECT-abcd');
   });
 
-  it('uses maxLen param for short ID', () => {
-    expect(formatBeadId('project-abcdefgh', 8)).toBe('BD-abcdefgh');
-    expect(formatBeadId('project-abcdefgh', 4)).toBe('BD-abcd');
+  it('upper-cases ids without a dash', () => {
+    expect(formatBeadId('nodash')).toBe('NODASH');
   });
 });
 

--- a/src/lib/bead-utils.ts
+++ b/src/lib/bead-utils.ts
@@ -8,17 +8,23 @@
 import type { BeadStatus } from "@/types";
 
 /**
- * Format bead ID for display.
- * @param id - Raw bead ID (e.g., "beads-kanban-ui-jkk.1" or "BD-abc123")
+ * Format bead ID for display, preserving the workspace prefix.
+ *
+ * Beads supports arbitrary per-workspace ID prefixes (`bd init --prefix`),
+ * e.g. `pa-pne9`, `dc-xyz`, `beads-web-2m8`. The prefix is everything before
+ * the last dash and is upper-cased for display. The suffix after the last
+ * dash is kept as-is (real IDs use lower-case + digits) and truncated to
+ * `maxLen`. IDs without a dash are returned upper-cased.
+ *
+ * @param id - Raw bead ID (e.g., "pa-pne9", "beads-web-2m8", "BD-abc123")
  * @param maxLen - Max chars for the short ID portion (6 for cards, 8 for detail)
  */
 export function formatBeadId(id: string, maxLen = 6): string {
-  if (id.startsWith("BD-") || id.startsWith("bd-")) {
-    return id.length > maxLen + 3 ? `BD-${id.slice(-maxLen)}` : id.toUpperCase();
-  }
-  const parts = id.split("-");
-  const shortId = parts[parts.length - 1];
-  return `BD-${shortId.slice(0, maxLen)}`;
+  const dashIdx = id.lastIndexOf("-");
+  if (dashIdx === -1) return id.toUpperCase();
+  const prefix = id.slice(0, dashIdx).toUpperCase();
+  const shortId = id.slice(dashIdx + 1, dashIdx + 1 + maxLen);
+  return `${prefix}-${shortId}`;
 }
 
 /**


### PR DESCRIPTION
Fixes three small frontend display bugs reported by @inconceivablelabs.

### #24 — `formatBeadId` discarded the workspace prefix
It re-prefixed every non-`bd` id with `BD-`, so `pa-pne9` showed as `BD-pne9`. Now the real prefix is preserved and upper-cased:
- `pa-pne9` → `PA-pne9`
- `dc-xyz` → `DC-xyz`
- `beads-web-2m8` → `BEADS-WEB-2m8`

The old `BD-`/non-`BD` branches are unified into one. Existing tests encoded the buggy output and were updated; added workspace-prefix and no-dash cases.

> Note: workspaces with long multi-segment prefixes (like this repo's own `beads-web-`) now render the full prefix on cards. If that reads too long we can truncate the prefix in a follow-up.

### #25 — kanban card collapsed every non-epic type to "Task"
`getTypeLabel` returned `epic ? "Epic" : "Task"`, so a `bug` showed as "Task". Now it renders the actual `issue_type` capitalized (`bug` → "Bug", `feature` → "Feature"), matching the detail view.

### #23 — misleading `dolt://` placeholder
The project-settings dialog placeholder read `dolt://host:port/database`, but the parser only accepts `dolt://<dbname>` (host/port are hardcoded). Changed to `dolt://database_name`.

### Testing
- `vitest run src/lib/__tests__/bead-utils.test.ts` — 23 pass
- `npm run build` — ok

Closes #23
Closes #24
Closes #25