### PR TITLE
feat(ui): first-class issue types + richer type filter (beads-web-1c3.2)

### DIFF
--- a/src/app/project/kanban-board.tsx
+++ b/src/app/project/kanban-board.tsx
@@ -36,6 +36,8 @@ import { useTheme } from "@/hooks/use-theme";
 import { useWorktreeStatuses } from "@/hooks/use-worktree-statuses";
 import { isBlocked } from "@/lib/bead-utils";
 import { getUnknownStatusBeads, getUnknownStatusNames } from "@/lib/beads-parser";
+import { getIssueTypeMeta } from "@/lib/issue-types";
+import type { IssueTypeFilter } from "@/lib/issue-types";
 import { isDoltProject } from "@/lib/utils";
 import type { Bead, BeadStatus } from "@/types";
 
@@ -49,11 +51,6 @@ const COLUMNS: { status: BeadStatus; title: string }[] = [
   { status: "inreview", title: "In Review" },
   { status: "closed", title: "Closed" },
 ];
-
-/**
- * Issue type filter options
- */
-type IssueTypeFilter = "all" | "epics" | "tasks";
 
 /**
  * Main Kanban board component with 4 columns, search, filter, and keyboard navigation
@@ -90,7 +87,7 @@ export default function KanbanBoard() {
     availableOwners,
   } = useBeadFilters(beads, ticketNumbers, 300);
 
-  // Issue type filter state (epics vs tasks)
+  // Issue type filter state ("all" or a specific issue type)
   const [typeFilter, setTypeFilter] = useState<IssueTypeFilter>("all");
 
   // Dolt project detection and filesystem path resolution
@@ -159,7 +156,8 @@ export default function KanbanBoard() {
 
   /**
    * Filter to only top-level beads (no parent_id)
-   * Then apply issue type filter (epics vs tasks)
+   * Then apply the issue type filter ("all" or a specific type).
+   * Unknown/missing issue types resolve to "task" via getIssueTypeMeta.
    * Child tasks should not appear in columns - they appear inside epic cards
    */
   const topLevelBeads = useMemo(() => {
@@ -167,10 +165,7 @@ export default function KanbanBoard() {
 
     // Apply issue type filter
     if (typeFilter === "all") return topLevel;
-    if (typeFilter === "epics") return topLevel.filter(b => b.issue_type === "epic");
-    if (typeFilter === "tasks") return topLevel.filter(b => b.issue_type !== "epic");
-
-    return topLevel;
+    return topLevel.filter(b => getIssueTypeMeta(b.issue_type).value === typeFilter);
   }, [filteredBeads, typeFilter]);
 
   /**

--- a/src/components/bead-card.tsx
+++ b/src/components/bead-card.tsx
@@ -6,6 +6,7 @@ import { CopyableText } from "@/components/copyable-text";
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "@/hooks/use-theme";
 import { formatBeadId, formatWorktreePath, isBlocked, truncate } from "@/lib/bead-utils";
+import { getIssueTypeMeta } from "@/lib/issue-types";
 import { cn } from "@/lib/utils";
 import type { Bead, WorktreeStatus, PRStatus, StatusBadgeInfo } from "@/types";
 
@@ -125,10 +126,11 @@ function getPRChecksDisplay(prStatus: PRStatus): { icon: React.ReactNode; text: 
 }
 
 /**
- * Get the display label for the bead type
+ * Get the display label for the bead type.
+ * Delegates to the shared issue-type metadata (safe fallback to "Task").
  */
 function getTypeLabel(bead: Bead): string {
-  return bead.issue_type === "epic" ? "Epic" : "Task";
+  return getIssueTypeMeta(bead.issue_type).label;
 }
 
 /**
@@ -151,6 +153,10 @@ export function BeadCard({ bead, allBeads, ticketNumber, worktreeStatus, prStatu
   const blocked = isBlocked(bead, allBeads);
   const commentCount = (bead.comments ?? []).length;
   const relatedCount = (bead.relates_to ?? []).length;
+
+  // Issue-type metadata (icon + theme color) from the shared source of truth
+  const typeMeta = getIssueTypeMeta(bead.issue_type);
+  const TypeIcon = typeMeta.icon;
 
   const hasWorktree = worktreeStatus?.exists ?? false;
   const hasPR = prStatus?.pr !== null && prStatus?.pr !== undefined;
@@ -311,7 +317,8 @@ export function BeadCard({ bead, allBeads, ticketNumber, worktreeStatus, prStatu
               Blocked
             </span>
           )}
-          <span className="theme-badge text-[10px] font-medium px-1.5 py-0.5 bg-surface-overlay text-t-tertiary">
+          <span className="theme-badge inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 bg-surface-overlay text-t-tertiary">
+            <TypeIcon className={cn("size-3 shrink-0", typeMeta.colorClass)} aria-hidden="true" />
             {getTypeLabel(bead)}
           </span>
           {bead.priority !== undefined && bead.priority <= 2 && (
@@ -385,7 +392,10 @@ export function BeadCard({ bead, allBeads, ticketNumber, worktreeStatus, prStatu
                   {bead._statusBadge.label}
                 </Badge>
               )}
-              <Badge variant="outline" size="xs" className="theme-badge">{getTypeLabel(bead)}</Badge>
+              <Badge variant="outline" size="xs" className="theme-badge">
+                <TypeIcon className={cn("shrink-0", typeMeta.colorClass)} aria-hidden="true" />
+                {getTypeLabel(bead)}
+              </Badge>
             </div>
           </div>
 

--- a/src/components/create-bead-dialog.tsx
+++ b/src/components/create-bead-dialog.tsx
@@ -21,13 +21,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import * as api from "@/lib/api";
-
-const ISSUE_TYPES = [
-  { value: "task", label: "Task" },
-  { value: "bug", label: "Bug" },
-  { value: "feature", label: "Feature" },
-  { value: "epic", label: "Epic" },
-];
+import { ISSUE_TYPES } from "@/lib/issue-types";
+import { cn } from "@/lib/utils";
 
 const PRIORITIES = [
   { value: "0", label: "P0 — Critical" },
@@ -158,11 +153,17 @@ export function CreateBeadDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent className="bg-surface-raised border-b-default">
-                    {ISSUE_TYPES.map((t) => (
-                      <SelectItem key={t.value} value={t.value} className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary">
-                        {t.label}
-                      </SelectItem>
-                    ))}
+                    {ISSUE_TYPES.map((t) => {
+                      const Icon = t.icon;
+                      return (
+                        <SelectItem key={t.value} value={t.value} className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary">
+                          <span className="flex items-center gap-2">
+                            <Icon className={cn("size-3.5 shrink-0", t.colorClass)} aria-hidden="true" />
+                            {t.label}
+                          </span>
+                        </SelectItem>
+                      );
+                    })}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/components/quick-filter-bar.tsx
+++ b/src/components/quick-filter-bar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-import { Search, X, ArrowUpDown, SlidersHorizontal, BrainCircuit, Bot, AlertTriangle, Plus } from 'lucide-react';
+import { Search, X, ArrowUpDown, SlidersHorizontal, BrainCircuit, Bot, AlertTriangle, Plus, Shapes } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -15,17 +15,18 @@ import {
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
   TooltipProvider,
 } from '@/components/ui/tooltip';
+import { ISSUE_TYPES, getIssueTypeMeta } from '@/lib/issue-types';
+import type { IssueTypeFilter } from '@/lib/issue-types';
 import { cn } from '@/lib/utils';
 import type { BeadStatus } from '@/types';
 
-type TypeFilter = 'all' | 'epics' | 'tasks';
+type TypeFilter = IssueTypeFilter;
 type SortField = 'ticket_number' | 'created_at';
 type SortDirection = 'asc' | 'desc';
 
@@ -82,12 +83,6 @@ interface QuickFilterBarProps {
   onNewBead?: () => void;
 }
 
-const TYPE_OPTIONS: { value: TypeFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'epics', label: 'Epics' },
-  { value: 'tasks', label: 'Tasks' },
-];
-
 const SORT_OPTIONS: { value: string; label: string; field: SortField; direction: SortDirection }[] = [
   { value: 'ticket_number_desc', label: 'Ticket # (Newest)', field: 'ticket_number', direction: 'desc' },
   { value: 'ticket_number_asc', label: 'Ticket # (Oldest)', field: 'ticket_number', direction: 'asc' },
@@ -134,6 +129,10 @@ export function QuickFilterBar({
   onNewBead,
 }: QuickFilterBarProps) {
   const currentSortValue = `${sortField}_${sortDirection}`;
+
+  // Active issue-type filter metadata for the type dropdown trigger
+  const activeType = typeFilter === 'all' ? null : getIssueTypeMeta(typeFilter);
+  const TypeTriggerIcon = activeType?.icon ?? Shapes;
 
   const handleSortOptionSelect = (value: string) => {
     const option = SORT_OPTIONS.find((opt) => opt.value === value);
@@ -184,24 +183,49 @@ export function QuickFilterBar({
         </Button>
       )}
 
-      {/* Type Filter & Today - Unified Tabs */}
-      <Tabs
-        value={typeFilter}
-        onValueChange={(value) => onTypeFilterChange(value as TypeFilter)}
-        className="h-8"
-      >
-        <TabsList className="h-8 bg-surface-overlay/50 p-0.5">
-          {TYPE_OPTIONS.map((option) => (
-            <TabsTrigger
-              key={option.value}
-              value={option.value}
-              className="h-7 px-3 text-sm font-medium data-[state=active]:bg-surface-overlay data-[state=active]:text-t-primary data-[state=inactive]:text-t-tertiary data-[state=inactive]:hover:text-t-secondary"
-            >
-              {option.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
+      {/* Type Filter Dropdown */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn(
+              'h-8 px-3 gap-1.5 bg-surface-overlay/50 text-sm font-medium',
+              activeType ? 'text-t-primary' : 'text-t-tertiary hover:text-t-secondary'
+            )}
+            aria-label="Filter by issue type"
+          >
+            <TypeTriggerIcon className={cn('size-4 shrink-0', activeType?.colorClass)} aria-hidden="true" />
+            {activeType ? activeType.label : 'All types'}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="bg-surface-raised border-b-default">
+          <DropdownMenuCheckboxItem
+            checked={typeFilter === 'all'}
+            onCheckedChange={() => onTypeFilterChange('all')}
+            className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary"
+          >
+            All types
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator className="bg-surface-overlay" />
+          {ISSUE_TYPES.map((option) => {
+            const Icon = option.icon;
+            return (
+              <DropdownMenuCheckboxItem
+                key={option.value}
+                checked={typeFilter === option.value}
+                onCheckedChange={() => onTypeFilterChange(option.value)}
+                className="text-t-secondary focus:bg-surface-overlay focus:text-t-primary"
+              >
+                <span className="flex items-center gap-2">
+                  <Icon className={cn('size-3.5 shrink-0', option.colorClass)} aria-hidden="true" />
+                  {option.label}
+                </span>
+              </DropdownMenuCheckboxItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       {/* Today's Active Toggle - styled to match tabs */}
       <button

--- a/src/lib/__tests__/issue-types.test.ts
+++ b/src/lib/__tests__/issue-types.test.ts
@@ -1,0 +1,36 @@
+import { CircleDot } from 'lucide-react';
+import { describe, it, expect } from 'vitest';
+
+import { ISSUE_TYPES, getIssueTypeMeta } from '@/lib/issue-types';
+
+describe('getIssueTypeMeta', () => {
+  it('returns matching metadata for every known type', () => {
+    for (const meta of ISSUE_TYPES) {
+      const result = getIssueTypeMeta(meta.value);
+      expect(result.value).toBe(meta.value);
+      expect(result.label).toBe(meta.label);
+      expect(result.icon).toBe(meta.icon);
+      expect(result.colorClass).toBe(meta.colorClass);
+    }
+  });
+
+  it('resolves the newer issue types added in bd v1.0', () => {
+    expect(getIssueTypeMeta('story').label).toBe('Story');
+    expect(getIssueTypeMeta('spike').label).toBe('Spike');
+    expect(getIssueTypeMeta('milestone').label).toBe('Milestone');
+    expect(getIssueTypeMeta('epic').label).toBe('Epic');
+  });
+
+  it('falls back to task for an unknown value', () => {
+    const result = getIssueTypeMeta('nonsense-type');
+    expect(result.value).toBe('task');
+    expect(result.label).toBe('Task');
+    expect(result.icon).toBe(CircleDot);
+  });
+
+  it('falls back to task for missing or empty values', () => {
+    expect(getIssueTypeMeta(undefined).value).toBe('task');
+    expect(getIssueTypeMeta(null).value).toBe('task');
+    expect(getIssueTypeMeta('').value).toBe('task');
+  });
+});

--- a/src/lib/issue-types.ts
+++ b/src/lib/issue-types.ts
@@ -1,0 +1,72 @@
+/**
+ * Single source of truth for bead issue types.
+ *
+ * bd v1.0 supports these issue types: task, bug, feature, epic, story, spike,
+ * milestone. This module centralizes their display metadata (label, Lucide
+ * icon, theme color token) so the create dialog, cards, and filters stay in
+ * sync. Add a new type here and every consumer picks it up.
+ *
+ * Color classes use the shared theme tokens defined in `themes.css`
+ * (text-danger, text-info, text-epic, …) so icons adapt across all themes.
+ */
+
+import { BookOpen, Bug, CircleDot, FlaskConical, Layers, Milestone, Sparkles } from "lucide-react";
+
+import type { LucideIcon } from "lucide-react";
+
+/** Canonical bd issue_type values that have first-class display metadata. */
+export type IssueTypeValue =
+  | "task"
+  | "bug"
+  | "feature"
+  | "epic"
+  | "story"
+  | "spike"
+  | "milestone";
+
+/** Type filter selection: every issue type plus an "all" pass-through. */
+export type IssueTypeFilter = "all" | IssueTypeValue;
+
+/** Display metadata for a single issue type. */
+export interface IssueTypeMeta {
+  /** Canonical bd issue_type value. */
+  value: IssueTypeValue;
+  /** Human-readable label (e.g. "Milestone"). */
+  label: string;
+  /** Lucide icon component representing the type. */
+  icon: LucideIcon;
+  /** Tailwind text color class using a shared theme token. */
+  colorClass: string;
+}
+
+/**
+ * Ordered list of issue types. Order drives the create-bead Select and the
+ * type filter menu, so keep the most common types first.
+ */
+export const ISSUE_TYPES: readonly IssueTypeMeta[] = [
+  { value: "task", label: "Task", icon: CircleDot, colorClass: "text-t-tertiary" },
+  { value: "bug", label: "Bug", icon: Bug, colorClass: "text-danger" },
+  { value: "feature", label: "Feature", icon: Sparkles, colorClass: "text-info" },
+  { value: "epic", label: "Epic", icon: Layers, colorClass: "text-epic" },
+  { value: "story", label: "Story", icon: BookOpen, colorClass: "text-success" },
+  { value: "spike", label: "Spike", icon: FlaskConical, colorClass: "text-warning" },
+  { value: "milestone", label: "Milestone", icon: Milestone, colorClass: "text-status-review" },
+];
+
+const ISSUE_TYPE_MAP: Record<string, IssueTypeMeta> = Object.fromEntries(
+  ISSUE_TYPES.map((meta) => [meta.value, meta]),
+);
+
+/** Fallback metadata for unknown or missing issue types. */
+const FALLBACK_ISSUE_TYPE: IssueTypeMeta = ISSUE_TYPE_MAP.task;
+
+/**
+ * Resolve display metadata for an issue type.
+ *
+ * Returns the `task` metadata for unknown, empty, or missing values so callers
+ * always receive a usable icon, label, and color.
+ */
+export function getIssueTypeMeta(value?: string | null): IssueTypeMeta {
+  if (!value) return FALLBACK_ISSUE_TYPE;
+  return ISSUE_TYPE_MAP[value] ?? FALLBACK_ISSUE_TYPE;
+}


### PR DESCRIPTION
Part of epic beads-web-1c3; supersedes beads-web-2m8.

- New `src/lib/issue-types.ts` — single source of truth for all 7 bd v1.0 types (task, bug, feature, epic, story, spike, milestone): `{ value, label, icon (Lucide), colorClass }` + `getIssueTypeMeta(value?)` with a safe fallback to `task`.
- The create-bead dialog Select, the card type badges (icon + theme color), and `getTypeLabel` now all render from the module.
- Kanban type filter: the old **All / Epics / Tasks** tabs become a type **dropdown** (All + 7 types), consistent with the adjacent Sort/Filter menus. Note: "Task" now filters by literal `issue_type === "task"` (the previous "all non-epic" grouping is gone).
- Epic-detection logic (`issue_type === "epic"`) left fully intact.

### Testing
- new `src/lib/__tests__/issue-types.test.ts` (4 cases: known types + unknown/empty/null fallback) — pass
- `npm run build` — ok (type-checked); ESLint clean

> Overlaps PR #32 on the `getTypeLabel` function only. Merge #32 first; this branch resolves to the metadata-based version.