### PR TITLE
feat(dist): Scoop manifest + install docs (addresses #2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,12 @@ jobs:
           find artifacts -type f -exec mv {} release/ \;
           ls -la release/
 
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
@@ -95,3 +101,36 @@ jobs:
           tag_name: ${{ inputs.version || github.ref_name }}
           files: release/*
           generate_release_notes: true
+
+      # Keep the self-hosted Scoop manifest (bucket/beads-web.json) in sync with
+      # each release: refresh version + Windows-exe hash and commit to main.
+      # Mirrors the Nix hash-refresh auto-commit already used by ci.yml.
+      - name: Checkout main for Scoop manifest
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          path: repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Scoop manifest
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.version || github.ref_name }}"
+          VERSION="${TAG#v}"
+          HASH="$(sha256sum release/beads-web-win-x64.exe | cut -d' ' -f1)"
+          cd repo
+          jq --arg v "$VERSION" --arg h "$HASH" --arg tag "$TAG" \
+            '.version = $v
+             | .architecture."64bit".url = "https://github.com/weselow/beads-web/releases/download/" + $tag + "/beads-web-win-x64.exe#/beads-web.exe"
+             | .architecture."64bit".hash = $h' \
+            bucket/beads-web.json > bucket/beads-web.json.tmp
+          mv bucket/beads-web.json.tmp bucket/beads-web.json
+          if git diff --quiet -- bucket/beads-web.json; then
+            echo "Scoop manifest already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bucket/beads-web.json
+          git commit -m "chore(scoop): update manifest for $TAG"
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ Download the binary for your platform from [GitHub Releases](https://github.com/
 | macOS Intel | `beads-web-darwin-x64` |
 | Linux x64 | `beads-web-linux-x64` |
 
+Each release also ships a `SHA256SUMS.txt` to verify your download.
+
+### Package managers
+
+**Scoop (Windows):**
+
+```powershell
+scoop bucket add beads-web https://github.com/weselow/beads-web
+scoop install beads-web
+```
+
+Update later with `scoop update beads-web`.
+
+**Nix (macOS / Linux / WSL):**
+
+```bash
+nix run github:weselow/beads-web
+```
+
 ### Run
 
 ```bash

--- a/bucket/beads-web.json
+++ b/bucket/beads-web.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.11.2",
+    "description": "Visual Kanban board and multi-project dashboard for beads task tracking",
+    "homepage": "https://github.com/weselow/beads-web",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/weselow/beads-web/releases/download/v0.11.2/beads-web-win-x64.exe#/beads-web.exe",
+            "hash": "7c915361274ed45e5dd3411a84dd6a73a873079a8a71d28ea649af632035ff93"
+        }
+    },
+    "bin": "beads-web.exe",
+    "notes": [
+        "beads-web needs the Beads CLI (bd) on your PATH: https://github.com/steveyegge/beads",
+        "Run 'beads-web' and open http://localhost:3008"
+    ],
+    "checkver": {
+        "github": "https://github.com/weselow/beads-web"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/weselow/beads-web/releases/download/v$version/beads-web-win-x64.exe#/beads-web.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Windows-first package-manager distribution via Scoop. Part of #2 (does **not** fully close it — winget + Homebrew remain, they need an external repo/token).

### Scoop
- `bucket/beads-web.json` — self-hosted Scoop manifest: v0.11.2 `beads-web-win-x64.exe` with its real SHA256, `checkver` + `autoupdate` against GitHub releases, `bin: beads-web.exe` (via the `#/beads-web.exe` URL fragment).
- Users install with:
  ```powershell
  scoop bucket add beads-web https://github.com/weselow/beads-web
  scoop install beads-web
  ```

### Release automation (`release.yml`)
- Publishes `SHA256SUMS.txt` as a release asset.
- Auto-refreshes the Scoop manifest (version / url / hash) and commits it to `main` on each release — mirrors the existing Nix hash-refresh auto-commit in `ci.yml`. (Runs from the tag-triggered release job; no-ops if the manifest is already current.)

### Docs
- `README` Installation now documents Scoop and the already-working `nix run github:weselow/beads-web`.

### Notes
- No app code changed. JSON + YAML validated locally.
- The manifest ships with the real hash for the current release, so `scoop install` works immediately.