### PR TITLE
fix(tests): repair 6 silently failing vitest tests (beads-web-fk5)

### DIFF
--- a/src/components/__tests__/update-banner.test.tsx
+++ b/src/components/__tests__/update-banner.test.tsx
@@ -53,7 +53,7 @@ describe('UpdateBanner', () => {
       expect(screen.getByText('Update available: v0.4.0')).toBeInTheDocument();
     });
 
-    const link = screen.getByText('Download from GitHub');
+    const link = screen.getByText('GitHub');
     expect(link).toHaveAttribute('href', 'https://github.com/example/releases/v0.4.0');
     expect(link).toHaveAttribute('target', '_blank');
   });

--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -13,6 +13,7 @@ function mockResponse(data: unknown, status = 200) {
     ok: status >= 200 && status < 300,
     status,
     statusText: status === 200 ? 'OK' : 'Error',
+    headers: new Headers(),
     json: () => Promise.resolve(data),
   } as Response;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
-import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -8,7 +9,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
-    exclude: ['node_modules', 'tests/**'],
+    exclude: ['node_modules', 'tests/**', '**/.worktrees/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Six vitest tests were failing silently — no CI runs vitest on push/PR, so they went unnoticed. Three unrelated root causes:

1. **`api.test.ts` (5 tests)** — `mockResponse()` returned no `headers`, so `fetchApi`'s 204-check `res.headers.get('content-length')` threw a `TypeError` on every 200-status test (`create` ×2, `update`, `read`, `version.check`). Fixed by stubbing `headers: new Headers()`.
2. **`update-banner.test.tsx` (1 test)** — a banner redesign renamed the download link text from "Download from GitHub" to "GitHub"; the test still queried the old text. Updated the query to match the component.
3. **`vitest.config.ts`** — added `**/.worktrees/**` to `exclude` so subagent git worktrees no longer pollute the run (previously caused ~115 false failures). Also fixed pre-existing import-order warnings that were blocking the pre-commit hook.

## Verification

Full suite green locally: **8 files, 60 tests passing**.

Closes beads-web-fk5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)