### PR TITLE
docs(readme): build-from-source workflow + fix dev-mode gotchas (#29)

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -127,27 +127,66 @@ chmod +x beads-web-*
 beads-web-win-x64.exe
 ```
 
-Откройте http://localhost:3007. Frontend встроен в бинарник — Node.js и Rust не требуются.
+Откройте http://localhost:3008. Frontend встроен в бинарник — Node.js и Rust не требуются.
 
 ## Разработка
 
-Для контрибьюторов и локальной разработки:
+Требования: Node.js 20+, [Rust toolchain](https://rustup.rs/) и [Beads CLI](https://github.com/steveyegge/beads) (`bd`) в PATH.
 
 ```bash
 git clone https://github.com/weselow/beads-web.git
 cd beads-web
 npm install
-
-# Терминал 1: Frontend dev server
-npm run dev
-
-# Терминал 2: Rust backend
-cd server && cargo run
 ```
 
-Требования: Node.js 20+, Rust toolchain.
+Есть два сценария: **режим разработки** (frontend с горячей перезагрузкой) и **сборка из исходников** (готовый бинарник).
 
-Примечание: `next dev` требует закомментировать `output: 'export'` в `next.config.js`.
+### Режим разработки (горячая перезагрузка frontend)
+
+Dev-сервер Next.js (порт 3007) отдаёт frontend с горячей перезагрузкой; бэкенд на Rust (порт 3008) отдаёт API. Они общаются между собой через CORS — на бэкенде он открыт.
+
+1. **Укажите frontend адрес бэкенда:**
+
+   ```bash
+   cp .env.local.example .env.local   # задаёт NEXT_PUBLIC_BACKEND_URL=http://localhost:3008
+   ```
+
+2. **Сначала соберите папку `out/`** (пока `output: 'export'` ещё включён). Сервер на Rust встраивает `out/` через rust-embed, поэтому она должна существовать до сборки бэкенда:
+
+   ```bash
+   npm run build
+   ```
+
+3. **Только после этого** закомментируйте `output: 'export'` в `next.config.js` — `next dev` несовместим со статическим экспортом.
+
+4. **Запустите оба сервера** в разных терминалах:
+
+   ```bash
+   npm run dev              # Терминал 1 — frontend на http://localhost:3007
+   cd server && cargo run   # Терминал 2 — бэкенд/API на http://localhost:3008
+   ```
+
+5. Откройте **http://localhost:3007**. Правки frontend перезагружаются на лету; запросы к API уходят на бэкенд на порт 3008.
+
+> Шаг с `.env.local` / `NEXT_PUBLIC_BACKEND_URL` нужен **только для разработки**. Для сборки готового бинарника уберите его (или оставьте переменную незаданной) — там frontend и бэкенд работают на одном адресе.
+
+### Сборка из исходников (готовый бинарник)
+
+Собирает тот же самодостаточный бинарник, что публикует CI в [Releases](https://github.com/weselow/beads-web/releases/latest) — frontend встроен, поэтому Node.js и Rust при запуске не нужны.
+
+```bash
+npm install
+# оставьте `output: 'export'` включённым в next.config.js (это значение по умолчанию)
+npm run build                 # статический экспорт → out/
+cd server
+cargo build --release         # бинарник → server/target/release/beads-server (.exe на Windows)
+```
+
+Запустите бинарник и откройте **http://localhost:3008**:
+
+```bash
+./server/target/release/beads-server
+```
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -153,23 +153,62 @@ Open http://localhost:3008. The frontend is embedded in the binary — no Node.j
 
 ## Development
 
-For contributing or local development:
+Prerequisites: Node.js 20+, [Rust toolchain](https://rustup.rs/), and the [Beads CLI](https://github.com/steveyegge/beads) (`bd`) in PATH.
 
 ```bash
 git clone https://github.com/weselow/beads-web.git
 cd beads-web
 npm install
-
-# Terminal 1: Frontend dev server
-npm run dev
-
-# Terminal 2: Rust backend
-cd server && cargo run
 ```
 
-Prerequisites: Node.js 20+, Rust toolchain.
+There are two workflows: **Dev Mode** (frontend hot-reload) and **Build from Source** (release binary).
 
-Note: `next dev` requires commenting out `output: 'export'` in `next.config.js`.
+### Dev Mode (frontend hot-reload)
+
+The Next.js dev server (port 3007) serves the frontend with hot-reload; the Rust backend (port 3008) serves the API. They talk cross-origin — CORS is open on the backend.
+
+1. **Point the frontend at the backend:**
+
+   ```bash
+   cp .env.local.example .env.local   # sets NEXT_PUBLIC_BACKEND_URL=http://localhost:3008
+   ```
+
+2. **Generate the `out/` folder once** (with `output: 'export'` still enabled). The Rust server embeds `out/` via rust-embed, so it must exist before you build the backend:
+
+   ```bash
+   npm run build
+   ```
+
+3. **Then** comment out `output: 'export'` in `next.config.js` — `next dev` is incompatible with static export.
+
+4. **Run both servers** in separate terminals:
+
+   ```bash
+   npm run dev              # Terminal 1 — frontend on http://localhost:3007
+   cd server && cargo run   # Terminal 2 — backend/API on http://localhost:3008
+   ```
+
+5. Open **http://localhost:3007**. Frontend edits hot-reload; API requests go to the backend on :3008.
+
+> The `.env.local` / `NEXT_PUBLIC_BACKEND_URL` step is **dev-only**. Remove it (or leave it unset) for a release build, where frontend and backend share one origin.
+
+### Build from Source (release binary)
+
+Produces the same self-contained binary that CI publishes to [Releases](https://github.com/weselow/beads-web/releases/latest) — the frontend is embedded, so no Node.js or Rust is needed at runtime.
+
+```bash
+npm install
+# keep `output: 'export'` enabled in next.config.js (the default)
+npm run build                 # static export → out/
+cd server
+cargo build --release         # binary → server/target/release/beads-server (.exe on Windows)
+```
+
+Run the binary and open **http://localhost:3008**:
+
+```bash
+./server/target/release/beads-server
+```
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

Rewrites the **Development** section of `README.md` and `README-ru.md` into two clear workflows — **Dev Mode** (frontend hot-reload) and **Build from Source** (release binary) — as requested in #29.

While verifying the setup against the actual code, I found and fixed three real defects (so this is not a verbatim copy of the snippet proposed in the issue):

1. **Dev-mode ordering contradiction.** `output: 'export'` cannot be simultaneously commented out (required for `next dev`) *and* enabled (required for `npm run build` to emit `out/`). The docs now build `out/` **first**, then comment out `output: 'export'` for the dev server.
2. **Missing env step.** The frontend reaches the backend only via `NEXT_PUBLIC_BACKEND_URL`. The dev server on :3007 needs `.env.local` (copied from `.env.local.example`) pointing at `http://localhost:3008`; CORS is open on the backend. Marked dev-only.
3. **Wrong port in `README-ru.md`.** After running the downloaded binary it said open `:3007`; the binary listens on `:3008` (now matches the English README).

## Verified against source

- dev server → `:3007` (`package.json`), backend → `:3008` (`BEADS_WEB_PORT`/`PORT`, `server/src/main.rs`)
- binary name `beads-server` (`server/Cargo.toml`), rust-embed folder `../out/`
- CORS `allow_origin(Any)` in `server/src/main.rs`

Addresses #29 (reported by @SamSpiri). Docs-only change — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)