### PR TITLE
feat(dist): Homebrew tap + winget + MIT LICENSE + release automation (#2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,13 +157,13 @@ jobs:
               -e "s|__LINUX_SHA__|${LINUX}|g" \
               repo/packaging/homebrew/beads-web.rb.tmpl > tap/Formula/beads-web.rb
           cd tap
-          if git diff --quiet -- Formula/beads-web.rb; then
+          git add Formula/beads-web.rb
+          if git diff --cached --quiet; then
             echo "Homebrew formula already up to date"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Formula/beads-web.rb
           git commit -m "beads-web ${VERSION}"
           git push origin HEAD:main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,58 @@ jobs:
           git add bucket/beads-web.json
           git commit -m "chore(scoop): update manifest for $TAG"
           git push origin main
+
+      - name: Update Homebrew formula
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "HOMEBREW_TAP_TOKEN not set — skipping Homebrew update"
+            exit 0
+          fi
+          TAG="${{ inputs.version || github.ref_name }}"
+          VERSION="${TAG#v}"
+          ARM=$(sha256sum release/beads-web-darwin-arm64 | cut -d' ' -f1)
+          INTEL=$(sha256sum release/beads-web-darwin-x64 | cut -d' ' -f1)
+          LINUX=$(sha256sum release/beads-web-linux-x64 | cut -d' ' -f1)
+          git clone --depth 1 "https://x-access-token:${TAP_TOKEN}@github.com/weselow/homebrew-beads-web.git" tap
+          mkdir -p tap/Formula
+          sed -e "s|__VERSION__|${VERSION}|g" \
+              -e "s|__ARM_SHA__|${ARM}|g" \
+              -e "s|__INTEL_SHA__|${INTEL}|g" \
+              -e "s|__LINUX_SHA__|${LINUX}|g" \
+              repo/packaging/homebrew/beads-web.rb.tmpl > tap/Formula/beads-web.rb
+          cd tap
+          if git diff --quiet -- Formula/beads-web.rb; then
+            echo "Homebrew formula already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/beads-web.rb
+          git commit -m "beads-web ${VERSION}"
+          git push origin HEAD:main
+
+  # `wingetcreate update` only works AFTER the package already exists in
+  # microsoft/winget-pkgs. The first submission is a one-time manual step:
+  #   wingetcreate submit packaging/winget --token <PAT>
+  # This job no-ops when WINGET_TOKEN is absent.
+  winget:
+    needs: release
+    runs-on: windows-latest
+    steps:
+      - name: Submit winget manifest
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN not set — skipping winget submission"
+            exit 0
+          }
+          $tag = "${{ inputs.version || github.ref_name }}"
+          $version = $tag.TrimStart('v')
+          $url = "https://github.com/weselow/beads-web/releases/download/$tag/beads-web-win-x64.exe"
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update weselow.beads-web --version $version --urls $url --submit --token $env:WINGET_TOKEN

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 weselow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README-ru.md
+++ b/README-ru.md
@@ -116,6 +116,20 @@ Beads Web даёт вам Kanban-доску в реальном времени, 
 | macOS Intel | `beads-web-darwin-x64` |
 | Linux x64 | `beads-web-linux-x64` |
 
+### Менеджеры пакетов
+
+**Homebrew (macOS / Linux):**
+
+```bash
+brew install weselow/beads-web/beads-web
+```
+
+**winget (Windows):**
+
+```powershell
+winget install weselow.beads-web
+```
+
 ### Запуск
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ Update later with `scoop update beads-web`.
 nix run github:weselow/beads-web
 ```
 
+**Homebrew (macOS / Linux):**
+
+```bash
+brew install weselow/beads-web/beads-web
+```
+
+**winget (Windows):**
+
+```powershell
+winget install weselow.beads-web
+```
+
 ### Run
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "beads-web",
   "version": "0.11.2",
+  "license": "MIT",
   "scripts": {
     "dev": "next dev -p 3007",
     "build": "next build",

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,41 @@
+# Packaging
+
+This directory holds the package-manager sources used to distribute `beads-web`.
+Nothing here is built into the binary — these files feed the release automation in
+[`.github/workflows/release.yml`](../.github/workflows/release.yml).
+
+## `homebrew/`
+
+- `beads-web.rb.tmpl` — Homebrew formula template with `__VERSION__`, `__ARM_SHA__`,
+  `__INTEL_SHA__`, and `__LINUX_SHA__` placeholders.
+- `beads-web.rb` — a rendered copy of the template (bootstrap for v0.11.2 with real
+  hashes). Use it to seed the tap repo the first time.
+
+On each release the `Update Homebrew formula` step renders the template with the new
+version and freshly computed SHA-256 hashes and pushes the result to
+`weselow/homebrew-beads-web` as `Formula/beads-web.rb`. Users then install with:
+
+```
+brew install weselow/beads-web/beads-web
+```
+
+## `winget/`
+
+The three winget manifests (`version`, `installer`, `locale.en-US`) describe the
+Windows portable package `weselow.beads-web`. On each release the `winget` job runs
+`wingetcreate update` to submit a new version PR to
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
+
+`wingetcreate update` only works after the package already exists in winget-pkgs, so
+the **first** submission is a one-time manual step:
+
+```
+wingetcreate submit packaging/winget --token <PAT>
+```
+
+## Required repo secrets
+
+- `HOMEBREW_TAP_TOKEN` — a personal access token with push rights to
+  `weselow/homebrew-beads-web`. When absent, the Homebrew step no-ops.
+- `WINGET_TOKEN` — a personal access token used by `wingetcreate` to open the
+  winget-pkgs PR. When absent, the winget job no-ops.

--- a/packaging/homebrew/beads-web.rb
+++ b/packaging/homebrew/beads-web.rb
@@ -1,0 +1,40 @@
+class BeadsWeb < Formula
+  desc "Visual Kanban board and multi-project dashboard for beads task tracking"
+  homepage "https://github.com/weselow/beads-web"
+  version "0.11.2"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/weselow/beads-web/releases/download/v0.11.2/beads-web-darwin-arm64"
+      sha256 "ebee1d74a8a580c1c57d205234240d3e5da364398db56a50f7dcca9f66d69e47"
+    end
+    on_intel do
+      url "https://github.com/weselow/beads-web/releases/download/v0.11.2/beads-web-darwin-x64"
+      sha256 "8e60a0f372823ff6e1be9389e59059014ca51afae68be6a9183df65c43b9a8b5"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/weselow/beads-web/releases/download/v0.11.2/beads-web-linux-x64"
+      sha256 "7832f9680c10e355cae7c6058ab7fb1cbbc89b14793c9785afa588ce64b92111"
+    end
+  end
+
+  def install
+    bin.install Dir["beads-web-*"].first => "beads-web"
+  end
+
+  def caveats
+    <<~EOS
+      beads-web needs the Beads CLI (bd) on your PATH:
+        https://github.com/steveyegge/beads
+      Run `beads-web` and open http://localhost:3008
+    EOS
+  end
+
+  test do
+    assert_path_exists bin/"beads-web"
+  end
+end

--- a/packaging/homebrew/beads-web.rb.tmpl
+++ b/packaging/homebrew/beads-web.rb.tmpl
@@ -1,0 +1,40 @@
+class BeadsWeb < Formula
+  desc "Visual Kanban board and multi-project dashboard for beads task tracking"
+  homepage "https://github.com/weselow/beads-web"
+  version "__VERSION__"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/weselow/beads-web/releases/download/v__VERSION__/beads-web-darwin-arm64"
+      sha256 "__ARM_SHA__"
+    end
+    on_intel do
+      url "https://github.com/weselow/beads-web/releases/download/v__VERSION__/beads-web-darwin-x64"
+      sha256 "__INTEL_SHA__"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/weselow/beads-web/releases/download/v__VERSION__/beads-web-linux-x64"
+      sha256 "__LINUX_SHA__"
+    end
+  end
+
+  def install
+    bin.install Dir["beads-web-*"].first => "beads-web"
+  end
+
+  def caveats
+    <<~EOS
+      beads-web needs the Beads CLI (bd) on your PATH:
+        https://github.com/steveyegge/beads
+      Run `beads-web` and open http://localhost:3008
+    EOS
+  end
+
+  test do
+    assert_path_exists bin/"beads-web"
+  end
+end

--- a/packaging/winget/weselow.beads-web.installer.yaml
+++ b/packaging/winget/weselow.beads-web.installer.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: weselow.beads-web
+PackageVersion: 0.11.2
+InstallerType: portable
+Commands:
+  - beads-web
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/weselow/beads-web/releases/download/v0.11.2/beads-web-win-x64.exe
+    InstallerSha256: 7C915361274ED45E5DD3411A84DD6A73A873079A8A71D28EA649AF632035FF93
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/weselow.beads-web.locale.en-US.yaml
+++ b/packaging/winget/weselow.beads-web.locale.en-US.yaml
@@ -1,0 +1,19 @@
+PackageIdentifier: weselow.beads-web
+PackageVersion: 0.11.2
+PackageLocale: en-US
+Publisher: weselow
+PublisherUrl: https://github.com/weselow
+PublisherSupportUrl: https://github.com/weselow/beads-web/issues
+PackageName: beads-web
+PackageUrl: https://github.com/weselow/beads-web
+License: MIT
+LicenseUrl: https://github.com/weselow/beads-web/blob/main/LICENSE
+ShortDescription: Visual Kanban board and multi-project dashboard for beads task tracking
+Moniker: beads-web
+Tags:
+  - kanban
+  - beads
+  - task-tracker
+  - project-management
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/weselow.beads-web.yaml
+++ b/packaging/winget/weselow.beads-web.yaml
@@ -1,0 +1,5 @@
+PackageIdentifier: weselow.beads-web
+PackageVersion: 0.11.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Addresses #2 — adds package-manager distribution, licensing, and release automation.

## What's in this PR (5 parts)

1. **MIT LICENSE** — new `LICENSE` file (MIT, © 2026 weselow) plus `"license": "MIT"` in `package.json`.
2. **Homebrew** — `packaging/homebrew/beads-web.rb.tmpl` (template with `__VERSION__`/`__ARM_SHA__`/`__INTEL_SHA__`/`__LINUX_SHA__` placeholders) and `packaging/homebrew/beads-web.rb` (rendered bootstrap for v0.11.2 with real hashes) to seed the tap.
3. **winget** — three manifests under `packaging/winget/` (`version`, `installer`, `locale.en-US`) for `weselow.beads-web` (portable installer).
4. **Release automation** (`.github/workflows/release.yml`):
   - New `Update Homebrew formula` step in the `release` job — renders the template with the new version + fresh SHA-256 hashes and pushes `Formula/beads-web.rb` to the `weselow/homebrew-beads-web` tap.
   - New top-level `winget` job (needs: release) — downloads `wingetcreate` and submits a version update PR to microsoft/winget-pkgs.
   - Both no-op when their secret is absent.
5. **Docs** — `README.md` and `README-ru.md` now document `brew install weselow/beads-web/beads-web` and `winget install weselow.beads-web`; `packaging/README.md` explains the sources.

## Required repo secrets

- `HOMEBREW_TAP_TOKEN` — PAT with push rights to `weselow/homebrew-beads-web` (Homebrew step no-ops without it).
- `WINGET_TOKEN` — PAT used by `wingetcreate` to open the winget-pkgs PR (winget job no-ops without it).

## One-time manual setup

- Create the `weselow/homebrew-beads-web` tap repo and seed it with `packaging/homebrew/beads-web.rb` (as `Formula/beads-web.rb`).
- First winget publish: `wingetcreate submit packaging/winget --token <PAT>` — `wingetcreate update` (used by CI) only works once the package already exists in winget-pkgs.

## Validation

- All winget manifests and the full `release.yml` parse as valid YAML (js-yaml).
- `package.json` remains valid JSON.
- No JS/TS source touched; pre-commit ESLint hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
